### PR TITLE
Add Deepseek-V4 operator examples

### DIFF
--- a/examples/deepseek_v4/example_act_quant_kernel.py
+++ b/examples/deepseek_v4/example_act_quant_kernel.py
@@ -1,1 +1,152 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import os
+import tilelang
+import tilelang.language as T
+from tilelang import DataType
+import torch
+import torch_npu
+from typing import Tuple, Optional, Literal
+
+tilelang.cache.clear_cache()
+
+FP8 = "float8_e4m3"
+BF16 = "bfloat16"
+FP32 = "float32"
+INT32 = "int32"
+
+@tilelang.jit(target="npuir")
+def act_quant_kernel(
+    N: int,
+    block_M: int = 32, block_N: int = 32,
+    round_scale: bool = False
+):
+    M = T.symbolic("M")
+    
+    # INT8 quant attributes
+    int8_min = -128
+    int8_max = 127
+    int8_abs_max = 127.0
+    
+    m_num = M // block_M
+    n_num = N // block_N
+
+    @T.prim_func
+    def main(
+        X: T.Tensor([M, N], "bfloat16"),      # input BF16
+        Y: T.Tensor([M, N], "int8"),         # output INT8
+        S: T.Tensor([M, 1], "float32"),      # output scale [M, 1]
+    ):
+        
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bm = cid // n_num  
+            bn = cid % n_num   
+            
+            x_ub = T.alloc_shared([block_M, block_N], "bfloat16")  
+            x_ub_fp = T.alloc_shared([block_M, block_N], "float32")  
+            x_ub_half = T.alloc_shared([block_M, block_N], "float16")  
+            x_ub_fp_abs = T.alloc_shared([block_M, block_N], "float32") 
+            y_ub = T.alloc_shared([block_M, block_N], "int8")     
+            
+            max_ub = T.alloc_shared([block_M, 1], "float32")         
+            scale_ub = T.alloc_shared([block_M, 1], "float32")       
+            
+            # x_ub_fp_1 = T.alloc_shared([block_M, block_N], "float32")  
+            
+            T.copy(X[bm * block_M, bn * block_N], x_ub)
+            T.vcast(x_ub, x_ub_fp) 
+            T.vabs(x_ub_fp, x_ub_fp_abs)
+            T.reduce_max(x_ub_fp_abs, max_ub, dim=1)
+        
+            for i in T.Parallel(block_M):
+                scale_ub[i, 0] = max_ub[i, 0] / int8_abs_max
+        
+            for i, j in T.Parallel(block_M, block_N):
+                x_ub_fp[i, j] = x_ub_fp[i, j] / scale_ub[i, 0]
+
+            T.vclamp(x_ub_fp, x_ub_fp, -127.0, 127.0)
+            T.vcast(x_ub_fp, x_ub_fp, round_mode="round")
+
+            T.vcast(x_ub_fp, x_ub_half)
+            T.vcast(x_ub_half, y_ub)
+
+            T.copy(y_ub, Y[bm * block_M, bn * block_N], size = [block_M, block_N])
+            T.copy(scale_ub, S[bm * block_M, 0], size = [block_M, 1])
+    
+    return main
+
+def act_quant(
+    x: torch.Tensor, scale_fmt: Optional[str] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization.
+
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and its last dimension size must be divisible by `block_size`.
+        scale_fmt (Optional[str], optional): The format of the scale. Default is None.
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+
+    N = x.size(-1)
+    y = torch.empty_like(x, dtype=torch.int8)
+    #s = x.new_empty(*x.size()[:-1], N, dtype=torch.float32)
+    s = x.new_empty(N, 1, dtype=torch.float32)
+    kernel = act_quant_kernel(N, round_scale=scale_fmt is not None)
+    kernel(x.view(-1, N), y.view(-1, N), s.view(-1, N))
+    return y, s
+
+def act_quant_torch(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    PyTorch reference implementation of act_quant_kernel.
+    
+    Args:
+        x: Input tensor of shape [M, N], dtype torch.bfloat16.
+    
+    Returns:
+        y: Quantized tensor of shape [M, N], dtype torch.int8.
+        s: Scale factors of shape [M, 1], dtype torch.float32.
+    """
+    # Convert to float32 for accurate arithmetic (kernel does bf16->fp32)
+    x_f32 = x.float()                     # [M, N]
+    
+    # Step 1: per‑row maximum of absolute values
+    abs_max = x_f32.abs().max(dim=1, keepdim=True)[0]   # [M, 1]
+    # Step 2: compute scale = max / 127.0
+    # Avoid division by zero (kernel does not handle zero, but we add safety)
+    scale = abs_max / 127.0
+    scale = torch.where(scale == 0, torch.ones_like(scale), scale)
+    # Step 3: scale the row values
+    x_scaled = x_f32 / scale              # [M, N]
+    # Step 4: clamp to [-127, 127]
+    x_clamped = torch.clamp(x_scaled, -127.0, 127.0)
+    # Step 5: round to nearest integer
+    x_rounded = torch.round(x_clamped)    # float32 with integer values
+    # Step 6: convert to int8
+    y = x_rounded.to(torch.int8)          # [M, N]
+    s = scale                          
+    
+    return y, s
+
+def test_act_quant():
+    M = 64
+    N = 32
+    dtype = "bfloat16"
+    x = torch.randn(size=[M, N], dtype=eval("torch." + dtype)).npu()
+    y, s = act_quant(x)
+    y_ref, s_ref = act_quant_torch(x)
+    print("Start Testing: M = 64, N = 32")
+    print("y:", y)
+    print("y_ref:", y_ref)
+    print("s:", s)
+    print("s_ref:", s_ref)
+    assert torch.all(y == y_ref)
+    torch.testing.assert_close(s, s_ref, atol=1e-3, rtol=1e-3)
+    print("Comparison passed.")
+
+if __name__ == "__main__":
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+    torch.manual_seed(888)
+    test_act_quant()

--- a/examples/deepseek_v4/example_fp8_gemm_kernel.py
+++ b/examples/deepseek_v4/example_fp8_gemm_kernel.py
@@ -1,1 +1,215 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import os
+import torch
+import tilelang as tl
+import tilelang.language as T
+
+
+def _ceildiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _gen_fp8_e4m3_like_tensor(shape, device: torch.device) -> torch.Tensor:
+    # E4M3 finite range is approximately [-448, 448].
+    x = torch.randn(shape, dtype=torch.float32) * 96.0
+    x = torch.clamp(x, -448.0, 448.0)
+    if hasattr(torch, "float8_e4m3fn"):
+        x = x.to(torch.float8_e4m3fn).to(torch.float16)
+    else:
+        x = x.to(torch.float16)
+    return x.to(device).contiguous()
+
+
+@tl.jit(target="npuir")
+def fp8_gemm_kernel(
+    N, K, out_dtype="float16", in_dtype="float16", accum_dtype="float32"
+):
+    assert out_dtype in ["float16", "float32", "bfloat16"]
+
+    M = T.symbolic("M")
+    group_size = 128
+    block_M = 32
+    block_N = 128
+    block_K = 128
+
+    assert in_dtype in ["float16"]
+    assert group_size == block_N, "This kernel expects group_size == block_N"
+    assert N % block_N == 0, "N must be divisible by block_N"
+    assert K % block_K == 0, "K must be divisible by block_K"
+
+    @T.prim_func
+    def fp8_gemm_kernel_(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor((N, K), in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+        scales_a: T.Tensor((M, T.ceildiv(K, group_size)), "float32"),
+        scales_b: T.Tensor(
+            (T.ceildiv(N, group_size), T.ceildiv(K, group_size)), "float32"
+        ),
+    ):
+        # GPU 2D launch (by, bx) -> NPU 1D launch (cid) mapping.
+        with T.Kernel(T.ceildiv(M, block_M) * T.ceildiv(N, block_N), is_npu=True) as (
+            cid,
+            _,
+        ):
+            bx = cid % T.ceildiv(N, block_N)
+            by = cid // T.ceildiv(N, block_N)
+
+            A_shared = T.alloc_shared((block_M, block_K), in_dtype)
+            B_shared = T.alloc_shared((block_N, block_K), in_dtype)
+            Scale_C_shared = T.alloc_shared((block_M), "float32")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            C_local_accum = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local_accum)
+            k_iters = T.ceildiv(K, block_K)
+            for k in T.Pipelined(k_iters, num_stages=2):
+                k_start = k * block_K
+
+                T.copy(
+                    A[
+                        by * block_M : (by + 1) * block_M,
+                        k_start : k_start + block_K,
+                    ],
+                    A_shared,
+                )
+                T.copy(
+                    B[
+                        bx * block_N : (bx + 1) * block_N,
+                        k_start : k_start + block_K,
+                    ],
+                    B_shared,
+                )
+
+                scale_b = scales_b[bx * block_N // group_size, k]
+                for i in T.Parallel(block_M):
+                    Scale_C_shared[i] = scales_a[by * block_M + i, k] * scale_b
+
+                T.gemm(
+                    A_shared,
+                    B_shared,
+                    C_local,
+                    initC=True,
+                    b_transpose=True,
+                    size=[block_M, block_K, block_N],
+                )
+
+                for i, j in T.Parallel(block_M, block_N):
+                    C_local_accum[i, j] += C_local[i, j] * Scale_C_shared[i]
+
+            T.copy(
+                C_local_accum,
+                C[
+                    by * block_M : (by + 1) * block_M,
+                    bx * block_N : (bx + 1) * block_N,
+                ],
+            )
+
+    return fp8_gemm_kernel_
+
+
+def fp8_gemm_torch_ref(
+    a: torch.Tensor,
+    a_s: torch.Tensor,
+    b: torch.Tensor,
+    b_s: torch.Tensor,
+    group_size: int,
+    out_dtype: str,
+) -> torch.Tensor:
+    m, k = a.shape
+    n, _ = b.shape
+    k_groups = a_s.shape[1]
+    out = torch.zeros((m, n), dtype=torch.float32, device=a.device)
+
+    for kg in range(k_groups):
+        k0 = kg * group_size
+        k1 = min(k, k0 + group_size)
+
+        part = a[:, k0:k1].float() @ b[:, k0:k1].float().transpose(0, 1)
+        part = part * a_s[:, kg].float().unsqueeze(1)
+
+        for ng in range(b_s.shape[0]):
+            n0 = ng * group_size
+            n1 = min(n, n0 + group_size)
+            part[:, n0:n1] = part[:, n0:n1] * b_s[ng, kg].float()
+
+        out += part
+
+    if out_dtype == "float16":
+        return out.to(torch.float16)
+    if out_dtype == "bfloat16":
+        return out.to(torch.bfloat16)
+    return out
+
+
+def fp8_gemm(
+    a: torch.Tensor,
+    a_s: torch.Tensor,
+    b: torch.Tensor,
+    b_s: torch.Tensor,
+    out_dtype: str = "float16",
+    group_size: int = 128,
+) -> torch.Tensor:
+    assert a.is_contiguous() and b.is_contiguous(), "Input tensors must be contiguous"
+    assert a_s.is_contiguous() and b_s.is_contiguous(), (
+        "Scale tensors must be contiguous"
+    )
+
+    m, k = a.shape
+    n = b.shape[0]
+
+    kernel = fp8_gemm_kernel(
+        N=n,
+        K=k,
+        out_dtype=out_dtype,
+        in_dtype="float16",
+        accum_dtype="float32",
+    )
+
+    c = torch.empty((m, n), dtype=getattr(torch, out_dtype), device=a.device)
+    out = kernel(a, b, c, a_s, b_s)
+    if out is None:
+        return c
+    return out
+
+
+def run_test_case(m: int, n: int, k: int, out_dtype: str = "float16"):
+    group_size = 128
+    assert m % 32 == 0
+    assert n % 128 == 0
+    assert k % 128 == 0
+    k_groups = _ceildiv(k, group_size)
+    n_groups = _ceildiv(n, group_size)
+
+    # Use fp8_e4m3 range and quantization, then run kernel with fp16 carriers.
+    npu_device = torch.device("npu")
+    a = _gen_fp8_e4m3_like_tensor((m, k), npu_device)
+    b = _gen_fp8_e4m3_like_tensor((n, k), npu_device)
+
+    a_s = (
+        torch.rand((m, k_groups), dtype=torch.float32).npu() * 0.2 + 0.9
+    ).contiguous()
+    b_s = (
+        torch.rand((n_groups, k_groups), dtype=torch.float32).npu() * 0.2 + 0.9
+    ).contiguous()
+
+    out = fp8_gemm(a, a_s, b, b_s, out_dtype=out_dtype, group_size=group_size)
+    ref = fp8_gemm_torch_ref(a, a_s, b, b_s, group_size=group_size, out_dtype=out_dtype)
+
+    atol = 2e-2 if out_dtype in ("float16", "bfloat16") else 1e-2
+    rtol = 2e-2 if out_dtype in ("float16", "bfloat16") else 1e-2
+    torch.testing.assert_close(out.float(), ref.float(), rtol=rtol, atol=atol)
+
+
+def run_test():
+    run_test_case(m=128, n=256, k=256, out_dtype="float16")
+    run_test_case(m=96, n=128, k=256, out_dtype="float32")
+    run_test_case(m=128, n=256, k=256, out_dtype="bfloat16")
+    print("\033[92mFP8 GEMM NPU test passed.\033[0m")
+
+
+if __name__ == "__main__":
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+    torch.npu.set_device(0)
+    tl.cache.clear_cache()
+    run_test()

--- a/examples/deepseek_v4/example_hc_split_sinkhorn_kernel.py
+++ b/examples/deepseek_v4/example_hc_split_sinkhorn_kernel.py
@@ -1,1 +1,209 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import os
+import torch
+import torch_npu
+import tilelang
+import tilelang.language as T
+import torch.nn.functional as F
+from typing import Tuple, Optional
+
+
+tilelang.set_log_level("WARNING")
+
+FP8 = "float8_e4m3"
+BF16 = "bfloat16"
+FP32 = "float32"
+INT32 = "int32"
+
+@tilelang.jit(target="npuir")
+def hc_split_sinkhorn_kernel(hc: int, sinkhorn_iters: int, eps: float):
+    n = T.symbolic("n")
+    mix_hc = (2 + hc) * hc 
+    hc_full = tilelang.cdiv(hc * 4, 32) * 32 // 4
+    dtype = FP32
+    block_M = 48 
+    n_num = tilelang.cdiv(n, block_M) 
+
+    @T.prim_func
+    def hc_split_sinkhorn_kernel_(
+        mixes: T.Tensor((n, mix_hc), dtype),
+        hc_scale: T.Tensor((3,), dtype), 
+        hc_base: T.Tensor((mix_hc,), dtype), 
+        pre: T.Tensor((n, hc), dtype),
+        post: T.Tensor((n, hc), dtype),
+        comb: T.Tensor((n, hc, hc), dtype),
+    ):
+        with T.Kernel(n_num, is_npu=True) as (cid, _): 
+            mixes_shared = T.alloc_shared((block_M, hc), dtype)
+            mixes_shared_2 = T.alloc_shared((block_M, mix_hc - 2 * hc), dtype)
+            hc_scaled = T.alloc_shared((3,), dtype)
+            hc_based = T.alloc_shared((1, hc), dtype)
+            hc_based_2 = T.alloc_shared((1, mix_hc - 2 * hc), dtype)
+            pre_ub = T.alloc_shared((block_M, hc), dtype)
+            post_ub = T.alloc_shared((block_M, hc), dtype)
+            comb_frag = T.alloc_shared((block_M, hc, hc_full), dtype)
+            
+            BLOCK = T.min(block_M, n - cid * block_M)
+            # calculate pre
+            T.copy(hc_scale, hc_scaled)
+            T.copy(mixes[cid * block_M, 0], mixes_shared, size=[BLOCK, hc])
+            T.copy(hc_base[ : hc], hc_based[0, :])
+            for i, j in T.Parallel(block_M, hc):
+                pre_ub[i, j] = T.sigmoid(mixes_shared[i, j] * hc_scaled[0] + hc_based[0, j]) + eps
+            T.copy(pre_ub, pre[cid * block_M , 0], size=[BLOCK, hc])
+            
+            # calculate post
+            T.copy(mixes[cid * block_M , hc], mixes_shared, size=[BLOCK, hc])
+            T.copy(hc_base[hc : hc * 2], hc_based[0, :])
+            for i, j in T.Parallel(block_M, hc):
+                post_ub[i, j] = 2 * T.sigmoid(mixes_shared[i, j] * hc_scaled[1] + hc_based[0, j]) 
+            T.copy(post_ub, post[cid * block_M , 0], size=[BLOCK, hc])
+            
+            # calculate comb
+            T.copy(mixes[cid * block_M , hc * 2], mixes_shared_2, size=[BLOCK, mix_hc - 2 * hc])
+            T.copy(hc_base[hc * 2 : ], hc_based_2[0, :])
+            for k, i, j in T.Parallel(block_M, hc, hc):
+                comb_frag[k, i, j] = mixes_shared_2[k, i * hc + j] * hc_scaled[2] + hc_based_2[0, i * hc + j]
+
+            row_sum = T.alloc_shared((block_M, hc, 1), dtype)
+            col_sum = T.alloc_shared((block_M, 1, hc_full), dtype)
+
+            # comb = comb.softmax(-1) + eps
+            row_max = T.alloc_shared((block_M, hc, 1), dtype)
+            T.reduce_max(comb_frag, row_max, dim=2, size=[BLOCK, hc, hc])
+            for k, i, j in T.Parallel(block_M, hc, hc_full):
+                comb_frag[k, i, j] = T.exp(comb_frag[k, i, j] - row_max[k, i, 0])
+            T.reduce_sum(comb_frag, row_sum, dim=2, size=[BLOCK, hc, hc])
+            for k, i, j in T.Parallel(block_M, hc, hc_full):
+                comb_frag[k, i, j] = comb_frag[k, i, j] / row_sum[k, i, 0] + eps
+
+            # comb = comb / (comb.sum(-2) + eps)
+            T.reduce_sum(comb_frag, col_sum, dim=1, size=[BLOCK, hc, hc])
+            for k, i, j in T.Parallel(block_M, hc, hc_full):
+                comb_frag[k, i, j] = comb_frag[k, i, j] / (col_sum[k, 0, j] + eps)
+
+            for _ in T.serial(sinkhorn_iters - 1):
+                # comb = comb / (comb.sum(-1) + eps)
+                T.reduce_sum(comb_frag, row_sum, dim=2, size=[BLOCK, hc, hc])
+                T.vadd(row_sum, eps, row_sum)
+                T.vdiv(comb_frag, row_sum, comb_frag)
+
+                # comb = comb / (comb.sum(-2) + eps)
+                T.reduce_sum(comb_frag, col_sum, dim=1, size=[BLOCK, hc, hc])
+                T.vadd(col_sum, eps, col_sum)
+                T.vdiv(comb_frag, col_sum, comb_frag)
+
+            T.copy(comb_frag[0, 0, 0], comb[cid * block_M, 0, 0], size=[BLOCK, hc, hc])
+
+    return hc_split_sinkhorn_kernel_
+
+def singleton(cls):
+    _instances = {}
+    def wrapper(*args, **kwargs):
+        if cls not in _instances:
+            _instances[cls] = cls(*args, **kwargs)
+        return _instances[cls]
+    return wrapper
+
+@singleton
+class HcKernel:
+    def __init__(self, hc_mult, sinkhorn_iters, eps):
+        self.kernel = hc_split_sinkhorn_kernel(hc_mult, sinkhorn_iters, eps)
+        print('=========== HC has been compiled ======')
+    
+    def __call__(self, mixes, hc_scale, hc_base, pre, post, comb):
+        self.kernel(mixes, hc_scale, hc_base, pre, post, comb)
+
+
+def hc_split_sinkhorn(
+    mixes: torch.Tensor, 
+    hc_scale: torch.Tensor, 
+    hc_base: torch.Tensor,
+    hc_mult: int = 4, 
+    sinkhorn_iters: int = 20, 
+    eps: float = 1e-6, 
+    n: int = 32
+):
+    os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+    b, s, _ = mixes.size()
+    pre = mixes.new_empty(b, s, hc_mult)
+    post = mixes.new_empty(b, s, hc_mult)
+    comb = mixes.new_empty(b, s, hc_mult, hc_mult)
+    kernel = HcKernel(hc_mult, sinkhorn_iters, eps)
+    kernel(mixes.view(-1, (2 + hc_mult) * hc_mult), hc_scale, hc_base, pre, post, comb)
+    return pre, post, comb
+
+def hc_split_sinkhorn_torch(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int = 4,
+    sinkhorn_iters: int = 20,
+    eps: float = 1e-6,
+):
+    # mixes: [b, s, mix_hc], hc_scale: [3], hc_base: [mix_hc]
+    # mix_hc = (hc + 2) * hc
+    pre, post, comb = mixes.split([hc_mult, hc_mult, hc_mult * hc_mult], dim=-1)
+    comb = comb.unflatten(-1, (hc_mult, hc_mult))
+
+    pre = (
+        F.sigmoid(pre * hc_scale[0] + hc_base[:hc_mult].unsqueeze(0).unsqueeze(0)) + eps
+    )
+    post = 2 * F.sigmoid(
+        post * hc_scale[1] + hc_base[hc_mult : 2 * hc_mult].unsqueeze(0).unsqueeze(0)
+    )
+    comb = comb * hc_scale[2] + hc_base[2 * hc_mult :].view(hc_mult, hc_mult).unsqueeze(
+        0
+    ).unsqueeze(0)
+
+    comb = comb.softmax(-1) + eps
+    col_sum = comb.sum(-2, keepdim=True)
+    comb = comb / (col_sum + eps)
+    for _ in range(sinkhorn_iters - 1):
+        row_sum = comb.sum(-1, keepdim=True)
+        comb = comb / (row_sum + eps)
+        col_sum = comb.sum(-2, keepdim=True)
+        comb = comb / (col_sum + eps)
+    return pre, post, comb
+
+def test_hc(hc_mult: int = 4):
+    # n = batch_size * seq_len
+    dtype = FP32
+    mix_hc = (2 + hc_mult) * hc_mult
+
+    print("Start Testing: batch_size = 2, seq_len = 1024")
+    batch_size = 2
+    seq_len = 1024
+    mixes = torch.randn(size=[batch_size, seq_len, mix_hc], dtype=eval("torch." + dtype)).npu()
+    hc_scale  = torch.randn(size=[3], dtype=eval("torch." + dtype)).npu()
+    hc_base = torch.randn(size=[mix_hc], dtype=eval("torch." + dtype)).npu()
+    pre, post, comb = hc_split_sinkhorn(mixes, hc_scale, hc_base)
+    pre_cpu, post_cpu, comb_cpu = hc_split_sinkhorn_torch(mixes, hc_scale, hc_base)
+    
+    torch.testing.assert_close(pre, pre_cpu, rtol=1e-3, atol=1e-3)
+    print("\033[92m pre check passed!\033[0m")
+    torch.testing.assert_close(post, post_cpu, rtol=1e-3, atol=1e-3)
+    print("\033[92m post check passed!\033[0m")
+    torch.testing.assert_close(comb, comb_cpu, rtol=1e-3, atol=1e-3)
+    print("\033[92m comb check passed!\033[0m")
+
+    print("Start Testing: batch_size = 2, seq_len = 27")
+    batch_size = 2
+    seq_len = 27
+    mixes = torch.randn(size=[batch_size, seq_len, mix_hc], dtype=eval("torch." + dtype)).npu()
+    hc_scale  = torch.randn(size=[3], dtype=eval("torch." + dtype)).npu()
+    hc_base = torch.randn(size=[mix_hc], dtype=eval("torch." + dtype)).npu()
+    pre, post, comb = hc_split_sinkhorn(mixes, hc_scale, hc_base)
+    pre_cpu, post_cpu, comb_cpu = hc_split_sinkhorn_torch(mixes, hc_scale, hc_base)
+   
+    torch.testing.assert_close(pre, pre_cpu, rtol=1e-3, atol=1e-3)
+    print("\033[92m pre check passed!\033[0m")
+    torch.testing.assert_close(post, post_cpu, rtol=1e-3, atol=1e-3)
+    print("\033[92m post check passed!\033[0m")
+    torch.testing.assert_close(comb, comb_cpu, rtol=1e-3, atol=1e-3)
+    print("\033[92m comb check passed!\033[0m")
+    
+
+if __name__ == "__main__":
+    torch.manual_seed(888)
+    test_hc()

--- a/examples/deepseek_v4/example_mhc_post.py
+++ b/examples/deepseek_v4/example_mhc_post.py
@@ -1,1 +1,120 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import os
+import math
+import torch
+import torch_npu
+import tilelang
+import tilelang.language as T
+import torch.nn.functional as F
+from typing import Tuple, Optional
+
+os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+tilelang.set_log_level("WARNING")
+
+T.float16 = "float16"
+T.float32 = "float32"
+
+@tilelang.jit(target="npuir")
+def mhc_post_tilelang(hc: int, hidden: int, n_thr: int = 128, h_blk: int = 1024):
+    # rename for shorter code
+    n = T.symbolic("num_tokens")
+    h = hidden
+
+    h_blk = math.gcd(hidden, h_blk)
+
+    @T.prim_func
+    def mhc_post_tilelang_kernel_(
+        a: T.Tensor((n, hc, hc), T.float32),
+        b: T.Tensor((n, hc, h), T.float16),
+        c: T.Tensor((n, hc), T.float32),
+        d: T.Tensor((n, h), T.float16),
+        x: T.Tensor((n, hc, h), T.float16),
+    ):
+        with T.Kernel(n, threads=n_thr) as i_n:
+            x_shared = T.alloc_shared((hc, h_blk), T.float16)
+            b_shared = T.alloc_shared((hc, h_blk), T.float16)
+            d_shared = T.alloc_shared(h_blk, T.float16)
+
+            x_local = T.alloc_shared((hc, h_blk), T.float32)
+            b_local = T.alloc_shared((hc, h_blk), T.float32)
+            d_local = T.alloc_shared(h_blk, T.float32)
+
+            a_local = T.alloc_shared((hc, hc), T.float32)
+            c_local = T.alloc_shared(hc, T.float32)
+            T.copy(a[i_n, 0, 0], a_local)
+            T.copy(c[i_n, 0], c_local)
+
+            for i0_h in T.Pipelined(T.ceildiv(h, h_blk), num_stages=2):
+                T.copy(b[i_n, 0, i0_h * h_blk], b_shared)
+                T.copy(d[i_n, i0_h * h_blk], d_shared)
+
+                T.copy(b_shared, b_local)
+                T.copy(d_shared, d_local)
+                for i_hco, i1_h in T.Parallel(hc, h_blk):
+                    x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                    for i_hci in T.serial(hc):
+                        x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+                T.copy(x_local, x_shared)
+
+                T.copy(x_shared, x[i_n, 0, i0_h * h_blk])
+
+    return  mhc_post_tilelang_kernel_
+
+def mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    compiled_kernel = mhc_post_tilelang(residual.shape[-2], residual.shape[-1])
+    out = torch.empty_like(residual)
+    compiled_kernel(comb_res_mix, residual, post_layer_mix.squeeze(-1), x, out)
+    return out
+
+
+def mhc_post_ref(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    term2 = torch.bmm(comb_res_mix.mT, residual.float())
+    return (x.float().unsqueeze(-2) * post_layer_mix + term2).half()
+
+
+def generate_test_data(
+    n: int,
+    h: int,
+    hc_mult: int,
+) -> dict[str, torch.Tensor]:
+    """Generate test data for post operator."""
+    torch.random.manual_seed(42)
+
+    x = torch.randn((n, h), dtype=torch.float16).npu()
+    residual = torch.randn((n, hc_mult, h), dtype=torch.float16).npu()
+    post_layer_mix = torch.randn((n, hc_mult, 1), dtype=torch.float32).npu()
+    comb_res_mix = torch.randn((n, hc_mult, hc_mult), dtype=torch.float32).npu()
+
+    return {
+        "x": x,
+        "residual": residual,
+        "post_layer_mix": post_layer_mix,
+        "comb_res_mix": comb_res_mix,
+    }
+
+
+def test(n: int, h: int) -> None:
+    print(f"Testing mhc_post with {n=} {h=}")
+    test_data = generate_test_data(n=n, h=h, hc_mult=4)
+    out_tl = mhc_post(**test_data)
+    out_ref = mhc_post_ref(**test_data)
+    torch.testing.assert_close(out_tl, out_ref)
+    print("\033[92m out check passed!\033[0m")
+
+def main():
+    for n in [4096]:
+        for h in [1280, 2560, 7168]:
+            test(n=n, h=h)
+
+if __name__ == "__main__":
+    main()

--- a/examples/deepseek_v4/example_sparse_attn_kernel.py
+++ b/examples/deepseek_v4/example_sparse_attn_kernel.py
@@ -1,1 +1,240 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import os
+import torch
+import tilelang
+import tilelang.language as T
+
+from typing import Optional
+
+FP16 = "float16"
+FP32 = "float32"
+INT32 = "int32"
+
+
+@tilelang.jit(out_idx=[2], target="npuir")
+def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads, dim, max_top_k=640, scale=None,
+                       dtype=FP16, accum_dtype=FP32, indices_dtype=INT32):
+    if scale is None:
+        scale = (1.0 / dim) ** 0.5
+    else:
+        scale = scale
+    batch_size = T.symbolic("batchSize")
+    seq_len = T.symbolic("seqLen")
+    seq_len_kv = T.symbolic("seqLenKV")
+    top_k = T.symbolic("topK")
+    top_k_reserved = T.symbolic("topKReserved")
+
+    @T.prim_func
+    def sparseAttn(
+            Q: T.Tensor((batch_size, seq_len, num_heads, dim), dtype),
+            KV: T.Tensor((batch_size, seq_len_kv, dim), dtype),
+            Output: T.Tensor((batch_size, seq_len, num_heads, dim), dtype),
+            AttnSink: T.Tensor((num_heads, 1), accum_dtype),
+            TopKIndices: T.Tensor((batch_size, seq_len, top_k), indices_dtype),
+            SparseKVBuffer: T.Tensor((batch_size, seq_len, top_k_reserved, dim), dtype),
+            ValidMaskBuffer: T.Tensor((batch_size, seq_len, top_k_reserved), accum_dtype),
+            WorkspaceScore: T.Tensor((batch_size, seq_len, block_heads, top_k_reserved), accum_dtype),
+    ):
+        with T.Kernel(batch_size * seq_len, is_npu=True) as (cid, _):
+            by = cid // seq_len
+            bx = cid % seq_len
+            value_zero = 0
+
+            q_shared = T.alloc_shared((block_heads, dim), dtype)
+            kv_gather = T.alloc_shared((block_top_k_vec, dim), dtype)
+            kv_shared = T.alloc_shared((block_top_k_cube, dim), dtype)
+            o_shared = T.alloc_shared((block_heads, dim), dtype)
+            acc_s_cast = T.alloc_shared((block_heads, max_top_k), dtype)
+            attn_sink_shared = T.alloc_shared((block_heads, 1), accum_dtype)
+            
+            idxs = T.alloc_fragment((block_top_k_vec,), indices_dtype)
+            acc_s_block = T.alloc_fragment((block_heads, block_top_k_cube), accum_dtype)
+            acc_s = T.alloc_fragment((block_heads, max_top_k), accum_dtype)
+            acc_o = T.alloc_fragment((block_heads, dim), accum_dtype)
+            scores_max = T.alloc_fragment((block_heads, 1), accum_dtype)
+            scores_sum = T.alloc_fragment((block_heads, 1), accum_dtype)
+            valid_mask = T.alloc_fragment((1, max_top_k), accum_dtype)
+            valid_mask_block = T.alloc_fragment((block_top_k_vec,), accum_dtype)
+
+            for n in T.Pipelined(T.ceildiv(num_heads, block_heads), num_stages=2):
+                T.vbrc(value_zero, acc_o)
+                T.copy(Q[by, bx, n * block_heads, 0], q_shared)
+                if n == 0:
+                    for k in T.Pipelined(T.ceildiv(top_k_reserved, block_top_k_vec), num_stages=2):
+                        real_block_top_k = T.min(top_k - k * block_top_k_vec, block_top_k_vec)
+                        real_block_top_k = T.max(real_block_top_k, 0)
+                        T.copy(TopKIndices[by, bx, k * block_top_k_vec], idxs)
+                        T.vbrc(value_zero, valid_mask_block)
+                        T.vbrc(value_zero, kv_gather)
+                        for i in T.serial(real_block_top_k):
+                            cur_idx = idxs[i]
+                            if cur_idx != -1:
+                                valid_mask_block[i] = 1.
+                                T.copy(KV[by, cur_idx, 0], kv_gather[i, 0], size=[1, dim])
+                        T.copy(valid_mask_block, ValidMaskBuffer[by, bx, k * block_top_k_vec])
+                        T.copy(kv_gather, SparseKVBuffer[by, bx, k * block_top_k_vec, 0])
+
+                for k in T.Pipelined(T.ceildiv(top_k, block_top_k_cube), num_stages=2):
+                    T.copy(SparseKVBuffer[by, bx, k * block_top_k_cube, 0], kv_shared)
+                    T.gemm(q_shared, kv_shared, acc_s_block, initC=True, b_transpose=True)
+                    T.copy(acc_s_block, WorkspaceScore[by, bx, 0, k * block_top_k_cube])
+
+                T.copy(WorkspaceScore[by, bx, 0, 0], acc_s, size=[block_heads, top_k_reserved])
+                for i, j in T.Parallel(block_heads, max_top_k):
+                    acc_s[i, j] *= scale
+                T.reduce_max(acc_s, scores_max, dim=1, size=[block_heads, top_k])
+                for i, j in T.Parallel(block_heads, max_top_k):
+                    acc_s[i, j] = T.exp(acc_s[i, j] - scores_max[i, 0])
+                T.vbrc(value_zero, valid_mask)
+                T.copy(ValidMaskBuffer[by, bx, 0], valid_mask[0, 0], size=[1, top_k_reserved])
+                for i, j in T.Parallel(block_heads, max_top_k):
+                    acc_s[i, j] *= valid_mask[0, j]
+                T.reduce_sum(acc_s, scores_sum, dim=1, size=[block_heads, top_k])
+                T.copy(AttnSink[n * block_heads, 0], attn_sink_shared)
+                for i in T.Parallel(block_heads):
+                    scores_sum[i, 0] += T.exp(attn_sink_shared[i, 0] - scores_max[i, 0])
+                for i, j in T.Parallel(block_heads, max_top_k):
+                    acc_s[i, j] /= scores_sum[i, 0]
+                T.copy(acc_s, acc_s_cast)
+
+                for k in T.Pipelined(T.ceildiv(top_k, block_top_k_cube), num_stages=2):
+                    T.copy(SparseKVBuffer[by, bx, k * block_top_k_cube, 0], kv_shared)
+                    T.gemm(acc_s_cast[0, k * block_top_k_cube], kv_shared, acc_o, initC=False,
+                           size=[block_heads, block_top_k_cube, dim])
+                T.copy(acc_o, o_shared)
+                T.copy(o_shared, Output[by, bx, n * block_heads, 0])
+
+    return sparseAttn
+
+
+def next_divisible_number(num, divisor):
+    return num + divisor - (num % divisor) if num % divisor != 0 else num
+
+
+def sparse_attn(
+        q: torch.Tensor, kv: torch.Tensor, attn_sink: torch.Tensor, topk_idxs: torch.Tensor,
+        softmax_scale: Optional[float] = None
+):
+    block_vec = 32
+    block_cube = 128
+    block_heads = 16
+    max_top_k = 256
+    batch_size, seq_len, num_heads, dim = q.size()
+    top_k = topk_idxs.shape[-1]
+    if not hasattr(sparse_attn, 'kernel') or sparse_attn.num_heads != num_heads or sparse_attn.dim != dim:
+        os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
+        bytes_workspace = block_cube * dim * 2 + block_heads * block_cube * 4 * 2 + block_heads * dim * 4
+        os.environ['TILELANG_ASCEND_WORKSPACE_SIZE'] = str(bytes_workspace * 16)
+        sparse_attn.kernel = sparse_attn_kernel(block_vec, block_cube, block_heads, num_heads, dim, max_top_k, softmax_scale)
+        sparse_attn.num_heads = num_heads
+        sparse_attn.dim = dim
+    output = torch.empty((batch_size, seq_len, num_heads, dim), dtype=q.dtype, device=q.device)
+    sparse_kv_buffer = torch.empty((batch_size, seq_len, next_divisible_number(top_k, block_cube), dim),
+                                   dtype=q.dtype, device=q.device)
+    valid_mask_buffer = torch.empty((batch_size, seq_len, next_divisible_number(top_k, block_cube)),
+                                    dtype=attn_sink.dtype, device=attn_sink.device)
+    workspace_score = torch.empty((batch_size, seq_len, block_heads, next_divisible_number(top_k, block_cube)),
+                                  dtype=attn_sink.dtype, device=attn_sink.device)
+    output = sparse_attn.kernel(q, kv.contiguous(), attn_sink, topk_idxs, sparse_kv_buffer, valid_mask_buffer, workspace_score)
+    return output
+
+
+def gather_from_kv(KV, indices):
+    """Gather key-value pairs using indices for reference implementation"""
+    b, s1, k = indices.shape
+    batch_idx = torch.arange(b, device=KV.device).view(b, 1, 1).expand(-1, s1, k)
+    indices_flat = indices.long()
+    out = KV[batch_idx, indices_flat, :].squeeze(dim=2)
+
+    mask = (indices != -1).float().unsqueeze(-1)
+    out = out * mask
+
+    return out
+
+
+def softmax_with_sink(x: torch.Tensor, attn_sink: torch.Tensor, head_dim, dim=-1):
+    max_vals = torch.max(x, dim=dim, keepdim=True).values
+    exp_x = torch.exp(x - max_vals)
+    sum_exp = torch.sum(exp_x, dim=dim, keepdim=True)
+
+    sink_view_shape = [1] * x.dim()
+    sink_view_shape[head_dim if head_dim > 0 else head_dim % x.dim()] = x.shape[head_dim]
+
+    # attention sink
+    sink_term = torch.exp(attn_sink.view(sink_view_shape) - max_vals)
+    adjusted_sum = sum_exp + sink_term
+
+    return exp_x / adjusted_sum
+
+
+def sparse_attn_torch(q: torch.Tensor, kv: torch.Tensor, attn_sink: torch.Tensor, topk_idxs: torch.Tensor,
+                      softmax_scale: Optional[float] = None):
+    """Reference Sparse Attention kernel implemented in PyTorch"""
+    kv_sparse = gather_from_kv(kv, topk_idxs)
+    mask_acc_s = torch.where((topk_idxs == -1).unsqueeze(-2), -torch.inf, 0.)
+    mask_acc_s = mask_acc_s.to(device=q.device, dtype=torch.float32)
+    ref_output = softmax_with_sink(
+        ((q @ kv_sparse.transpose(-2, -1)).to(torch.float32) + mask_acc_s) * softmax_scale, attn_sink, head_dim=-2,
+        dim=-1).to(torch.float16) @ kv_sparse
+
+    return ref_output
+
+
+def rand_sparse_attn_input(batch_size, num_heads, seq_len, seq_len_kv, top_k, dim, seed=88888888, causal=True):
+    """Generate legalized random inputs for Sparse Attention"""
+    torch.manual_seed(seed)
+
+    # Generate inputs
+    q = torch.randn((batch_size, seq_len, num_heads, dim), dtype=torch.float16).npu()
+    kv = torch.randn((batch_size, seq_len_kv, dim), dtype=torch.float16).npu()
+    attn_sink = torch.randn((num_heads,), dtype=torch.float32).npu()
+    top_k_indices = torch.randint(low=0, high=seq_len_kv, size=(batch_size, seq_len, top_k), dtype=torch.int32).npu()
+
+    if causal:
+        # Apply causal mask on top_k_indices
+        max_len = max(seq_len, top_k)
+        causal_mask = torch.tril(torch.ones(max_len, max_len)).to(top_k_indices.device)
+        causal_mask = causal_mask[:seq_len, :top_k]
+        causal_mask = causal_mask.unsqueeze(dim=0).bool()
+        top_k_indices = torch.where(causal_mask, top_k_indices, -1)
+
+    scale = (1.0 / dim) ** 0.5
+
+    return {
+        'q': q,
+        'kv': kv,
+        'attn_sink': attn_sink,
+        'topk_idxs': top_k_indices,
+        'softmax_scale': scale,
+    }
+
+
+def generate_and_save_data(case_id, **kwargs):
+    inputs = rand_sparse_attn_input(**kwargs)
+    outputs = sparse_attn_torch(**inputs)
+    torch.save({'inputs': inputs, 'outputs': outputs}, f"case_{case_id}.pt")
+
+
+def generate_data():
+    generate_and_save_data(
+        case_id=0,
+        batch_size=1,
+        num_heads=32,
+        seq_len=4096,
+        seq_len_kv=4096,
+        top_k=128,
+        dim=512,
+    )
+
+
+def run_test():
+    data = torch.load("case_0.pt", map_location=torch.device('npu'))
+    output = sparse_attn(**data['inputs'])
+    print(output)
+    torch.testing.assert_close(data['outputs'], output, rtol=1e-2, atol=1e-2)
+    print('\033[92mAll check passed.\033[0m')
+
+
+if __name__ == "__main__":
+    generate_data()
+    run_test()

--- a/examples/deepseek_v4/example_sparse_attn_kernel_highperf.py
+++ b/examples/deepseek_v4/example_sparse_attn_kernel_highperf.py
@@ -1,1 +1,435 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import torch
+import tilelang
+import tilelang.language as T
+
+from typing import Optional
+
+
+@tilelang.jit(target="npuir")
+def sparse_attn_kernel(
+        batch,
+        seq_len,
+        seq_len_kv,
+        heads,
+        dim,
+        tail_dim,
+        top_k,
+        num_kernels,
+        sm_scale=None,
+        block_I=64,
+        block_K=64,
+):
+    # Validate input parameters
+    assert block_I % 2 == 0, "Block I size must be even"
+    assert dim == tilelang.math.next_power_of_2(
+        dim
+    ), f"haven't check padding correctness yet, dim={dim}"
+    assert tail_dim==0 or tail_dim == tilelang.math.next_power_of_2(
+        tail_dim
+    ), f"haven't check padding correctness yet, dim={tail_dim}"
+
+    # Set softmax scale if not provided
+    if sm_scale is None:
+        sm_scale = (1.0 / (dim + tail_dim)) ** 0.5
+    else:
+        sm_scale = sm_scale
+
+
+    # Calculate total number of logical kernels
+    num_logic_kernels = batch * seq_len
+
+    # Define data types
+    indices_dtype = "int32"
+    dtype = "bfloat16"
+    accum_dtype = "float"
+
+    # Set block size for head dimension
+    heads_half = heads // 2
+
+    # Calculate half block sizes for vector operations
+    block_I_half = block_I // 2
+
+    # Calculate shared block size for I and K dimensions
+    share_block_IK = max(block_I, block_K)
+
+    # Calculate full dimension (dim + tail_dim)
+    full_dim = dim + tail_dim
+    num_block_i = T.ceildiv(top_k, block_I)
+
+    # Define tensor shapes
+    shape_q = [batch, seq_len, heads, full_dim]
+    shape_kv = [batch, seq_len_kv, full_dim]
+    shape_out = [batch, seq_len, heads, dim]
+    shape_idx = [batch, seq_len, top_k]
+    shape_kv_sparse_work = [num_kernels, top_k, full_dim]
+    shape_s_work = [num_kernels, num_block_i, heads, block_I]
+    shape_o_work = [num_kernels, num_block_i, heads, dim]
+    shape_u_work = [num_kernels, num_block_i, heads, 1]
+
+    # Define the main sparse attention kernel using TileLang
+    @T.prim_func
+    def SparseAttnExp(
+            Q: T.Tensor(shape_q, dtype),
+            KV: T.Tensor(shape_kv, dtype),
+            Output: T.Tensor(shape_out, dtype),
+            attn_sink: T.Tensor((heads), accum_dtype),
+            Indices: T.Tensor(shape_idx, indices_dtype),
+            workspace_kv: T.Tensor(shape_kv_sparse_work, dtype),
+            workspace_s: T.Tensor(shape_s_work, accum_dtype),
+            workspace_p: T.Tensor(shape_s_work, dtype),
+            workspace_o: T.Tensor(shape_o_work, accum_dtype),
+            workspace_u: T.Tensor(shape_u_work, accum_dtype),
+    ):
+        # Launch NPU kernel with specified number of parallel kernels
+        with T.Kernel(num_kernels, is_npu=True) as (kernel_id, subid):
+            acc_s_scale = sm_scale
+
+            # Cube computation section (matrix operations)
+            with T.Scope("Cube"):
+                # Allocate L1 buffers for cube operations
+                l1_q = T.alloc_L1([heads, full_dim], dtype)
+                l1_p = T.alloc_L1([heads, block_I], dtype)
+                l1_kv_sparse = T.alloc_L1([block_I, full_dim], dtype)
+
+                # Allocate L0 buffer for accumulation
+                l0_c = T.alloc_L0C([heads, dim], accum_dtype)
+
+                # Process tasks in serial across logical kernels
+                for task_id in T.serial(T.ceildiv(num_logic_kernels, num_kernels)):
+                    logic_kernel_id = task_id * num_kernels
+                    logic_kernel_id = logic_kernel_id + kernel_id
+                    if logic_kernel_id < num_logic_kernels:
+                        # Calculate batch and sequence indices
+                        batch_id = logic_kernel_id // seq_len
+                        seq_id = logic_kernel_id % seq_len
+
+                        # Load query data to L1
+                        T.npuir_load_nd2nz(Q[batch_id, seq_id, 0, 0], l1_q, size=[heads, full_dim])
+
+                        # Process blocks along I dimension (top-k)
+                        for block_i_id in T.serial(T.ceildiv(top_k, block_I)):
+                            block_i_offset = block_i_id * block_I
+
+                            # Wait for Vector computation section synchronization
+                            with T.rs("PIPE_MTE2"):
+                                T.sync_block_wait(block_i_id)
+
+                            # Load sparse KV data to L1
+                            T.npuir_load_nd2nz(workspace_kv[kernel_id, block_i_offset, 0],
+                                               l1_kv_sparse, size=[block_I, full_dim])
+
+                            # Perform matrix multiplication (Q @ K^T)
+                            T.npuir_dot(l1_q, l1_kv_sparse, l0_c, initC=True, b_transpose=True,
+                                        size=[heads, full_dim, block_I])
+
+                            # Store intermediate results and synchronize
+                            with T.rs("PIPE_FIX"):
+                                T.npuir_store_fixpipe(l0_c, workspace_s[kernel_id, block_i_id, 0, 0], size=[heads, block_I],
+                                                      enable_nz2nd=True)
+                                T.sync_block_set(block_i_id)
+
+                        for block_i_id in T.serial(T.ceildiv(top_k, block_I)):
+                            block_i_offset = block_i_id * block_I
+                            # Load intermediate results for softmax
+                            with T.rs("PIPE_MTE2"):
+                                T.sync_block_wait(block_i_id)
+                                T.npuir_load_nd2nz(workspace_p[kernel_id, block_i_id, 0, 0], l1_p, size=[heads, block_I])
+
+                            # Perform matrix multiplication (P @ V)
+                            T.npuir_load_nd2nz(workspace_kv[kernel_id, block_i_offset, 0],
+                                               l1_kv_sparse, size=[block_I, full_dim])
+
+                            T.npuir_dot(l1_p, l1_kv_sparse, l0_c, initC=True,
+                                        size=[heads, block_I, dim])
+
+                            T.npuir_store_fixpipe(l0_c, workspace_o[kernel_id, block_i_id, 0, 0],
+                                                  size=[heads, dim], enable_nz2nd=True)
+
+                            # Synchronize after output computation
+                            with T.rs("PIPE_FIX"):
+                                T.sync_block_set(block_i_id)
+
+            # Vector computation section (softmax and normalization)
+            with T.Scope("Vector"):
+                value_zero = 0
+                value_ignore_index = -1
+                value_min = -T.infinity("float32")
+
+                # Allocate unified buffers for vector operations
+                ub_kv_sparse = T.alloc_ub([block_I_half, full_dim], dtype)
+                ub_indices = T.alloc_ub([1, block_I], indices_dtype)
+                ub_acc_o = T.alloc_ub([heads_half, dim], accum_dtype)
+                ub_acc_o_new = T.alloc_ub([heads_half, dim], accum_dtype)
+                ub_cross_kernel_16 = T.alloc_ub([heads_half, share_block_IK], dtype)
+                ub_cross_kernel_32 = T.alloc_ub([heads_half, share_block_IK], accum_dtype)
+
+                # Allocate buffers for softmax variables
+                ub_var_logsum = T.alloc_ub([heads_half, 1], accum_dtype)
+                ub_var_scores_max = T.alloc_ub([heads_half, 1], accum_dtype)
+                ub_var_scores_max_prev = T.alloc_ub([heads_half, 1], accum_dtype)
+                ub_var_scores_scale = T.alloc_ub([heads_half, 1], accum_dtype)
+                ub_var_scores_sum = T.alloc_ub([heads_half, 1], accum_dtype)
+                ub_var_valid_indices = T.alloc_ub([1, block_I], "bool")
+                ub_var_valid_mask = T.alloc_ub([1, block_I], "bool")
+                ub_var_valid_indices_32 = T.alloc_ub([1, block_I], accum_dtype)
+
+                ub_arrange_mask = T.alloc_ub([1, block_I], "int16")
+                T.npuir_arange(ub_arrange_mask, [0, 1], 0)
+
+                # Process tasks in serial across logical kernels
+                for task_id in T.serial(T.ceildiv(num_logic_kernels, num_kernels)):
+                    logic_kernel_id = task_id * num_kernels
+                    logic_kernel_id = logic_kernel_id + kernel_id
+                    if logic_kernel_id < num_logic_kernels:
+                        batch_id = logic_kernel_id // seq_len
+                        seq_id = logic_kernel_id % seq_len
+
+                        # Initialize softmax variables
+                        T.npuir_brc(value_zero, ub_var_logsum)
+                        T.npuir_brc(value_zero, ub_acc_o)
+                        T.npuir_brc(value_zero, ub_var_scores_scale)
+                        T.npuir_brc(value_min, ub_var_scores_max)
+
+                        # Process blocks along I dimension (top-k)
+                        for block_i_id in T.serial(T.ceildiv(top_k, block_I)):
+                            tail_size_i = T.min(top_k - block_i_id * block_I, block_I)
+                            tail_size_i_half = (tail_size_i + 1) // 2
+
+                            block_i_offset = block_i_id * block_I
+                            block_i_sub_offset = subid * tail_size_i_half
+                            tail_size_i_half = tail_size_i_half - (tail_size_i % 2) * subid
+
+                            # Load indices and gather sparse KV data (only for first head block)
+                            T.copy(Indices[batch_id, seq_id, block_i_offset], ub_indices, size=[1, block_I])
+                            if tail_size_i_half > 0:
+                                T.npuir_brc(value_zero, ub_kv_sparse)
+                                for idx_id in T.serial(tail_size_i_half):
+                                    current_index = ub_indices[0, block_i_sub_offset + idx_id]
+                                    if current_index >= 0 and current_index < seq_len_kv:
+                                        T.copy(KV[batch_id, current_index, 0], ub_kv_sparse[idx_id, 0],
+                                               size=[1, full_dim])
+
+                                # Store gathered KV data to workspace
+                                T.copy(ub_kv_sparse, workspace_kv[kernel_id, block_i_offset + block_i_sub_offset, 0],
+                                       size=[tail_size_i_half, full_dim])
+
+                            # Synchronize after KV gathering
+                            with T.rs("PIPE_MTE3"):
+                                T.sync_block_set(block_i_id)
+
+                        for block_i_id in T.serial(T.ceildiv(top_k, block_I)):
+                            # Save previous max scores for numerical stability
+                            T.copy(ub_var_scores_max, ub_var_scores_max_prev)
+                            block_i_offset = block_i_id * block_I
+                            T.copy(Indices[batch_id, seq_id, block_i_offset], ub_indices, size=[1, block_I])
+
+                            # Load attention scores from workspace
+                            with T.rs("PIPE_MTE2"):
+                                T.sync_block_wait(block_i_id)
+                                T.copy(workspace_s[kernel_id, block_i_id, subid * heads_half, 0],
+                                       ub_cross_kernel_32, size=[heads_half, block_I])
+
+                            # Apply softmax scaling and compute max
+                            T.npuir_mul(ub_cross_kernel_32, acc_s_scale, ub_cross_kernel_32)
+                            T.npuir_reduce(ub_cross_kernel_32, ub_var_scores_max, dims=[1], reduce_mode="max")
+
+                            # Update max scores and compute scaling factors
+                            if block_i_id != 0:
+                                T.npuir_max(ub_var_scores_max_prev, ub_var_scores_max, ub_var_scores_max)
+                                T.npuir_sub(ub_var_scores_max_prev, ub_var_scores_max, ub_var_scores_scale)
+                                T.npuir_exp(ub_var_scores_scale, ub_var_scores_scale)
+
+                            T.copy(ub_var_scores_scale, workspace_u[kernel_id, block_i_id, subid * heads_half, 0],
+                                   size=[heads_half, 1])
+                            # Apply softmax stabilization and compute exponentials
+                            T.npuir_sub(ub_cross_kernel_32, ub_var_scores_max, ub_cross_kernel_32)
+                            T.npuir_exp(ub_cross_kernel_32, ub_cross_kernel_32)
+
+                            # Create valid mask for incomplete blocks
+                            T.npuir_cmp(ub_indices, value_ignore_index, ub_var_valid_indices, "ne")
+                            tail_size_i = T.min(top_k - block_i_id * block_I, block_I)
+                            if tail_size_i < block_I:
+                                tail_size_i = tail_size_i
+                                T.npuir_cmp(ub_arrange_mask, tail_size_i, ub_var_valid_mask, "lt")
+                                T.npuir_and(ub_var_valid_indices, ub_var_valid_mask, ub_var_valid_indices)
+
+                            # Apply valid mask
+                            T.npuir_cast(ub_var_valid_indices, ub_var_valid_indices_32)
+                            T.npuir_mul(ub_cross_kernel_32, ub_var_valid_indices_32, ub_cross_kernel_32)
+                            T.npuir_cast(ub_cross_kernel_32, ub_cross_kernel_16, round_mode="rint",
+                                         size=[heads_half, block_I])
+
+                            # Store softmax results and synchronize
+                            with T.rs("PIPE_MTE3"):
+                                T.copy(ub_cross_kernel_16, workspace_p[kernel_id, block_i_id, subid * heads_half, 0],
+                                       size=[heads_half, block_I])
+                                T.sync_block_set(block_i_id)
+
+                            # Compute sum of exponential for softmax denominator
+                            T.npuir_reduce(ub_cross_kernel_32, ub_var_scores_sum, dims=[1], reduce_mode="sum")
+
+                            # Update logsum and accumulate output
+                            T.npuir_mul(ub_var_logsum, ub_var_scores_scale, ub_var_logsum)
+                            T.npuir_add(ub_var_logsum, ub_var_scores_sum, ub_var_logsum)
+
+                        for block_i_id in T.serial(T.ceildiv(top_k, block_I)):
+                            T.copy(workspace_u[kernel_id, block_i_id, subid * heads_half, 0],
+                                   ub_var_scores_scale,
+                                   size=[heads_half, 1])
+                            T.npuir_mul(ub_acc_o, ub_var_scores_scale, ub_acc_o)
+
+                            # Load and accumulate output values
+                            with T.rs("PIPE_MTE2"):
+                                T.sync_block_wait(block_i_id)
+                                T.copy(workspace_o[kernel_id, block_i_id, subid * heads_half, 0], ub_acc_o_new,
+                                       size=[heads_half, dim])
+
+                            T.npuir_add(ub_acc_o, ub_acc_o_new, ub_acc_o)
+
+                        # Normalize output by softmax denominator
+                        T.copy(attn_sink[subid * heads_half:(subid + 1) * heads_half], ub_var_scores_max_prev[:, 0])
+                        T.npuir_sub(ub_var_scores_max_prev, ub_var_scores_max, ub_var_scores_max_prev)
+                        T.npuir_exp(ub_var_scores_max_prev, ub_var_scores_max_prev)
+                        T.npuir_add(ub_var_logsum, ub_var_scores_max_prev, ub_var_logsum)
+                        T.npuir_div(ub_acc_o, ub_var_logsum, ub_acc_o)
+
+                        # Store final output results
+                        for block_k_id in T.serial(T.ceildiv(dim, block_K)):
+                            block_k_offset = block_k_id * block_K
+                            tail_size_k = dim - block_k_offset
+                            tail_size_k = T.min(tail_size_k, block_K)
+
+                            T.npuir_cast(ub_acc_o[0, block_k_offset], ub_cross_kernel_16, round_mode="rint",
+                                         size=[heads_half, tail_size_k])
+
+                            T.copy(ub_cross_kernel_16, Output[batch_id, seq_id, subid * heads_half, block_k_offset],
+                                   size=[heads_half, tail_size_k])
+
+    return SparseAttnExp
+
+
+def sparse_attn(
+        q: torch.Tensor, kv: torch.Tensor, attn_sink: torch.Tensor, topk_idxs: torch.Tensor,
+        softmax_scale: Optional[float] = None
+):
+    num_kernels = 24
+    block_I = 64
+    block_K = 64
+    batch, seq_len, heads, dim = q.size()
+    _, seq_len_kv, _ = kv.size()
+    _, _, top_k = topk_idxs.size()
+    num_block_i = torch.ceil(torch.tensor(top_k / block_I)).int().item()
+    kernel = sparse_attn_kernel(batch, seq_len, seq_len_kv, heads, dim, tail_dim=0, top_k=top_k,
+                                num_kernels=num_kernels, sm_scale=softmax_scale, block_I=block_I, block_K=block_K)
+    output = torch.empty((batch, seq_len, heads, dim), dtype=q.dtype).npu()
+    w_kv = torch.empty((num_kernels, top_k, dim), dtype=q.dtype).npu()
+    w_s = torch.empty((num_kernels, num_block_i, heads, block_I), dtype=attn_sink.dtype).npu()
+    w_p = torch.empty((num_kernels, num_block_i, heads, block_I), dtype=q.dtype).npu()
+    w_o = torch.empty((num_kernels, num_block_i, heads, dim), dtype=attn_sink.dtype).npu()
+    w_u = torch.empty((num_kernels, num_block_i, heads, 1), dtype=attn_sink.dtype).npu()
+    kernel(q, kv, output, attn_sink, topk_idxs, w_kv, w_s, w_p, w_o, w_u)
+    return output
+
+
+def gather_from_kv(KV, indices):
+    """Gather key-value pairs using indices for reference implementation"""
+    b, s1, k = indices.shape
+    batch_idx = torch.arange(b, device=KV.device).view(b, 1, 1).expand(-1, s1, k)
+    indices_flat = indices.long()
+    out = KV[batch_idx, indices_flat, :].squeeze(dim=2)
+    return out
+
+
+def softmax_with_sink(x: torch.Tensor, attn_sink: torch.Tensor, head_dim, dim=-1):
+    max_vals = torch.max(x, dim=dim, keepdim=True).values
+    exp_x = torch.exp(x - max_vals)
+    sum_exp = torch.sum(exp_x, dim=dim, keepdim=True)
+
+    sink_view_shape = [1] * x.dim()
+    sink_view_shape[head_dim if head_dim > 0 else head_dim % x.dim()] = x.shape[head_dim]
+
+    sink_term = torch.exp(attn_sink.view(sink_view_shape) - max_vals)
+    adjusted_sum = sum_exp + sink_term
+
+    return exp_x / adjusted_sum
+
+
+def sparse_attn_torch(q: torch.Tensor, kv: torch.Tensor, attn_sink: torch.Tensor, topk_idxs: torch.Tensor,
+                      softmax_scale: Optional[float] = None):
+    """Reference Sparse Attention kernel implemented in PyTorch"""
+    kv_sparse = gather_from_kv(kv, topk_idxs)
+    mask_acc_s = torch.where((topk_idxs == -1).unsqueeze(-2), -torch.inf, 0.)
+    mask_acc_s = mask_acc_s.to(device=q.device, dtype=torch.float32)
+    ref_output = softmax_with_sink(
+        ((q @ kv_sparse.transpose(-2, -1)).to(torch.float32) + mask_acc_s) * softmax_scale, attn_sink, head_dim=-2,
+        dim=-1).to(torch.bfloat16) @ kv_sparse
+
+    return ref_output
+
+
+def rand_sparse_attn_input(batch_size, num_heads, seq_len, seq_len_kv, top_k, dim, seed=88888888, causal=True):
+    """Generate legalized random inputs for Sparse Attention"""
+    torch.manual_seed(seed)
+
+    # Generate inputs
+    q = torch.randn((batch_size, seq_len, num_heads, dim), dtype=torch.bfloat16).npu()
+    kv = torch.randn((batch_size, seq_len_kv, dim), dtype=torch.bfloat16).npu()
+    attn_sink = torch.randn((num_heads,), dtype=torch.float32).npu()
+    top_k_indices = torch.randint(low=0, high=seq_len_kv, size=(batch_size, seq_len, top_k), dtype=torch.int32).npu()
+
+    if causal:
+        # Apply causal mask on top_k_indices
+        max_len = max(seq_len, top_k)
+        causal_mask = torch.tril(torch.ones(max_len, max_len)).to(top_k_indices.device)
+        causal_mask = causal_mask[:seq_len, :top_k]
+        causal_mask = causal_mask.unsqueeze(dim=0).bool()
+        top_k_indices = torch.where(causal_mask, top_k_indices, -1)
+
+    scale = (1.0 / dim) ** 0.5
+
+    return {
+        'q': q,
+        'kv': kv,
+        'attn_sink': attn_sink,
+        'topk_idxs': top_k_indices,
+        'softmax_scale': scale,
+    }
+
+
+def generate_and_save_data(case_id, **kwargs):
+    inputs = rand_sparse_attn_input(**kwargs)
+    outputs = sparse_attn_torch(**inputs)
+    torch.save({'inputs': inputs, 'outputs': outputs}, f"case_{case_id}.pt")
+
+
+def generate_data():
+    generate_and_save_data(
+        case_id=0,
+        batch_size=1,
+        num_heads=32,
+        seq_len=4096,
+        seq_len_kv=4096,
+        top_k=128,
+        dim=512,
+        # causal=False,
+    )
+
+
+def run_test(verify_result=True):
+    data = torch.load("case_0.pt", map_location=torch.device('npu'))
+    output = sparse_attn(**data['inputs'])
+    if verify_result:
+        print("torch:", data['outputs'])
+        print("output:", output)
+        torch.testing.assert_close(data['outputs'], output, rtol=1e-2, atol=1e-2)
+        print('\033[92mAll check passed.\033[0m')
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    # Generate data and run tests
+    generate_data()
+    run_test(verify_result=True)
+    # run_test(verify_result=False)


### PR DESCRIPTION
This PR adds 6 operator kernels for DeepSeek-V4 under the MLIR-Ascend backend:

- hc_split_sinkhorn_kernel
- mhc_post
- act_quant_kernel
- fp8_gemm_kernel
- sparse_attn_kernel
- sparse_attn_kernel_highperf

These kernels are implemented within the MLIR compilation pipeline and fully leverage Ascend NPU hardware capabilities, including matrix computation units and vector processing units. The integration enables efficient end-to-end execution of DeepSeek-V4 on Ascend platforms.

All kernels pass correctness and performance validation on Ascend hardware.