### PR TITLE
[AscendNPU-IR] Support the capabilities that high-performance operators must rely on

### DIFF
--- a/examples/elementwise/vec_add_2d_multi_buffer.py
+++ b/examples/elementwise/vec_add_2d_multi_buffer.py
@@ -1,0 +1,210 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+"""
+This is an example of how to manually implement multi-buffer and software pipelines
+using the interfaces provided by the expert mode to achieve ultimate performance.
+"""
+
+import argparse
+import torch
+
+import tilelang
+import tilelang.language as T
+
+parser = argparse.ArgumentParser(description="NPU Kernel Compilation")
+parser.add_argument("--M", type=int, default=4096, help="")
+parser.add_argument("--N", type=int, default=4096, help="")
+parser.add_argument("--block_M", type=int, default=128, help="")
+parser.add_argument("--block_N", type=int, default=128, help="")
+
+
+@tilelang.jit(
+    out_idx=[-1],
+    target="npuir",
+    pass_configs={
+        # Disable the auto multi buffer to implement it manually.
+        tilelang.PassConfigKey.NPUIR_ENABLE_AUTO_MULTI_BUFFER: False,
+        # Disable the automatic sync to manually use the sync interface in expert mode.
+        tilelang.PassConfigKey.NPUIR_DISABLE_HIVM_AUTO_INJECT_SYNC: True,
+    },
+)
+def vec_add(M, N, block_M, block_N):
+    m_num = M // block_M
+    n_num = N // block_N
+    dtype = "float16"
+    num_ph_kernels = 24 * 2
+    num_stages = 3
+    multi_A = (
+        3  # number of buffer slots for matrix A (also serves as pipeline depth for A)
+    )
+    multi_B = 2  # number of buffer slots for matrix B
+    num_lg_kernels = m_num * n_num
+    num_ph_kernels = min(num_ph_kernels, num_lg_kernels)
+
+    @T.macro
+    def init_flag():
+        # Initialize inter‑pipeline flags so that the first `wait_flag` does not block.
+        # The flag names follow the convention: "PIPE_XX" is set by the XX pipeline.
+        # Here we pre‑set "PIPE_MTE2" flags from MTE3 and V pipelines to satisfy
+        # early waits by MTE2 (the load pipeline) later.
+        for i in T.serial(multi_A):
+            with T.rs("PIPE_MTE3"):
+                T.set_flag(
+                    "PIPE_MTE2", i
+                )  # MTE3 signals MTE2 that A‑buffer slot i is initially free
+        for i in T.serial(multi_B):
+            with T.rs("PIPE_V"):
+                T.set_flag(
+                    "PIPE_MTE2", i
+                )  # V signals MTE2 that B‑buffer slot i is initially free
+
+    @T.macro
+    def clear_flag():
+        # Drain all pending flags before kernel exit to avoid deadlock in subsequent launches.
+        for i in T.serial(multi_A):
+            with T.rs("PIPE_MTE2"):
+                T.wait_flag(
+                    "PIPE_MTE3", i
+                )  # Wait until MTE3 has finished using buffer slot i
+        for i in T.serial(multi_B):
+            with T.rs("PIPE_MTE2"):
+                T.wait_flag(
+                    "PIPE_V", i
+                )  # Wait until V has finished using B‑buffer slot i
+
+    @T.macro
+    def load(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        VEC,
+        ph_id,
+        task_id,
+    ):
+        lg_id = task_id * num_ph_kernels + ph_id
+        bx = lg_id // n_num
+        bx *= block_M
+        by = lg_id % n_num
+        by *= block_N
+
+        with T.rs("PIPE_MTE2"):
+            # Wait until the A‑buffer slot (index = task_id % multi_A) is no longer
+            # needed by the store pipeline (MTE3). This guarantees the slot is free
+            # for a new load.
+            T.wait_flag("PIPE_MTE3", task_id % multi_A)
+            T.copy(
+                A[bx : bx + block_M, by : by + block_N], VEC[task_id % multi_A, :, :]
+            )
+
+            # Similarly, wait until the B‑buffer slot (index = task_id % multi_B)
+            # has been consumed by the compute pipeline (V), so it can be reused.
+            T.wait_flag("PIPE_V", task_id % multi_B)
+            T.copy(
+                B[bx : bx + block_M, by : by + block_N],
+                VEC[multi_A + task_id % multi_B, :, :],
+            )
+
+            # After both A and B are loaded for this task, signal the compute
+            # pipeline (V) that input data is ready. The flag index is modulo
+            # `num_stages` to match the software pipeline stage.
+            T.set_flag("PIPE_V", task_id % num_stages)
+
+    @T.macro
+    def compute(
+        VEC,
+        task_id,
+    ):
+        with T.rs("PIPE_V"):
+            # Wait for the load pipeline (MTE2) to finish loading both A and B
+            # for the current pipeline stage. The index matches the flag set in `load`.
+            T.wait_flag("PIPE_MTE2", task_id % num_stages)
+
+            T.vadd(
+                VEC[task_id % multi_A, :, :],
+                VEC[multi_A + task_id % multi_B, :, :],
+                VEC[task_id % multi_A, :, :],
+            )
+
+            # Signal the load pipeline that the B‑buffer slot just used is now free
+            # for the next load operation.
+            T.set_flag("PIPE_MTE2", task_id % multi_B)
+            # Signal the store pipeline (MTE3) that the result (stored in the A‑buffer
+            # slot) is ready to be written back.
+            T.set_flag("PIPE_MTE3", task_id % num_stages)
+
+    @T.macro
+    def store(
+        C: T.Tensor((M, N), dtype),
+        VEC,
+        ph_id,
+        task_id,
+    ):
+        lg_id = task_id * num_ph_kernels + ph_id
+        bx = lg_id // n_num
+        bx *= block_M
+        by = lg_id % n_num
+        by *= block_N
+
+        with T.rs("PIPE_MTE3"):
+            # Wait until the compute pipeline (V) has finished producing the result
+            # in the A‑buffer slot corresponding to this pipeline stage.
+            T.wait_flag("PIPE_V", task_id % num_stages)
+            T.copy(
+                VEC[task_id % multi_A, :, :], C[bx : bx + block_M, by : by + block_N]
+            )
+
+            # Signal the load pipeline that the A‑buffer slot is now free and can
+            # be reused for a new load.
+            T.set_flag("PIPE_MTE2", task_id % num_stages)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(num_ph_kernels, is_npu=True) as (ph_id, _):
+            # Unified buffer: first multi_A slices for A, next multi_B slices for B.
+            VEC = T.alloc_ub((multi_A + multi_B, block_M, block_N), dtype)
+
+            num_local_tasks = T.ceildiv(num_lg_kernels - ph_id, num_ph_kernels)
+
+            init_flag()
+
+            # Software pipeline with overlapping load, compute, and store.
+            for task_id in T.serial(num_local_tasks + 2):
+                if task_id < num_local_tasks:
+                    load(A, B, VEC, ph_id, task_id)
+                if task_id > 0 and task_id < num_local_tasks + 1:
+                    compute(VEC, task_id - 1)
+                if task_id > 1:
+                    store(C, VEC, ph_id, task_id - 2)
+
+            clear_flag()
+
+    return main
+
+
+def run_test(main_args):
+    kernel = vec_add(
+        main_args.M,
+        main_args.N,
+        main_args.block_M,
+        main_args.block_N,
+    )
+
+    torch.manual_seed(88888888)  # set the random seed for torch
+    shape = [main_args.M, main_args.N]
+    dtype = "float16"
+
+    a = torch.randn(size=shape, dtype=eval("torch." + dtype), device="npu")
+    b = torch.randn(size=shape, dtype=eval("torch." + dtype), device="npu")
+
+    ref_output = a + b
+    c = kernel(a, b)
+    torch.testing.assert_close(c, ref_output, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed!\033[0m")
+
+
+if __name__ == "__main__":
+    torch.npu.set_device(0)
+    args = parser.parse_args()
+    run_test(args)

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -19,6 +19,10 @@
 namespace tvm {
 namespace tl {
 
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAutoMultiBuffer, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableHivmAutoInjectSync, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnablePlanAndUpdateBufferAllocation, Bool);
+
 using namespace tir;
 
 NpuirOperand NpuirOperand::FromExpr(const PrimExpr &expr,

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -17,6 +17,13 @@
 namespace tvm {
 namespace tl {
 
+static constexpr const char *kEnableAutoMultiBuffer =
+    "npuir.enable_auto_multi_buffer";
+static constexpr const char *kDisableHivmAutoInjectSync =
+    "npuir.disable_hivm_auto_inject_sync";
+static constexpr const char *kEnablePlanAndUpdateBufferAllocation =
+    "tl.enable_plan_and_update_buffer_allocation";
+
 using namespace tir;
 
 class NpuirOperand {

--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1861,22 +1861,52 @@ void CodeGenTileLangNPUIRAPI::DotCodegen(const CallNode *op) {
   //                 outs(%alloc_9 : memref<128x64xf32,
   //                      #hivm.address_space<cc>>)
   tvm::tl::NpuirDot npuirop(op->args, this->vmap);
-  Array<PrimExpr> a_region_shape, b_region_shape;
-  for (int i = 0; i < npuirop.src0_range.size(); i++) {
-    a_region_shape.push_back(npuirop.src0_range[i].get()->extent);
-    b_region_shape.push_back(npuirop.src1_range[i].get()->extent);
-  }
+  auto extract_region_shape =
+      [](const Array<Range> &ranges) -> Array<PrimExpr> {
+    Array<PrimExpr> region_shape;
+    for (int i = ranges.size() - 2; i < ranges.size(); ++i) {
+      region_shape.push_back(ranges[i].get()->extent);
+    }
+    return region_shape;
+  };
+  auto a_region_shape = extract_region_shape(npuirop.src0_range);
+  auto b_region_shape = extract_region_shape(npuirop.src1_range);
 
   mlir::Location unknown_loc = builder.getUnknownLoc();
   mlir::IndexType idx_ty = builder.getIndexType();
-  mlir::Value a = GetVarValue(npuirop.src0->data.get());
-  mlir::Value b = GetVarValue(npuirop.src1->data.get());
-  mlir::Value c = GetVarValue(npuirop.dst->data.get());
+  mlir::Value a, b, c;
+  if (npuirop.src0_range.size() > 2) {
+    a = GenRankReducedSubviewFromRegion(npuirop.src0, npuirop.src0_range, 2);
+  } else {
+    a = GetVarValue(npuirop.src0->data.get());
+  }
+  if (npuirop.src1_range.size() > 2) {
+    b = GenRankReducedSubviewFromRegion(npuirop.src1, npuirop.src1_range, 2);
+  } else {
+    b = GetVarValue(npuirop.src1->data.get());
+  }
+  if (npuirop.dst_range.size() > 2) {
+    c = GenRankReducedSubviewFromRegion(npuirop.dst, npuirop.dst_range, 2);
+  } else {
+    c = GetVarValue(npuirop.dst->data.get());
+  }
   mlir::TypeRange result_tensors = {};
   mlir::Value init_condition = MakeValue(npuirop.initC);
-  mlir::Value real_m = CreateIndexCastOp(MakeValue(a_region_shape[0]));
-  mlir::Value real_k = CreateIndexCastOp(MakeValue(b_region_shape[0]));
-  mlir::Value real_n = CreateIndexCastOp(MakeValue(b_region_shape[1]));
+
+  int m_idx = npuirop.a_transpose ? 1 : 0;
+  int k_a_idx = npuirop.a_transpose ? 0 : 1;
+  int k_b_idx = npuirop.b_transpose ? 1 : 0;
+  int n_idx = npuirop.b_transpose ? 0 : 1;
+  ICHECK(analyzer_->CanProveEqual(a_region_shape[k_a_idx],
+                                  b_region_shape[k_b_idx]))
+      << "matmul inner dimension mismatch: "
+      << "a" << (npuirop.a_transpose ? ".T" : "")
+      << " K = " << a_region_shape[k_a_idx] << ", b"
+      << (npuirop.b_transpose ? ".T" : "")
+      << " K = " << b_region_shape[k_b_idx];
+  mlir::Value real_m = CreateIndexCastOp(MakeValue(a_region_shape[m_idx]));
+  mlir::Value real_k = CreateIndexCastOp(MakeValue(a_region_shape[k_a_idx]));
+  mlir::Value real_n = CreateIndexCastOp(MakeValue(b_region_shape[n_idx]));
   mlir::Value per_channel_bias = mlir::Value{};
   mlir::UnitAttr a_transpose =
       npuirop.a_transpose ? builder.getUnitAttr() : mlir::UnitAttr();

--- a/testing/npuir/linalg_ops/test_rank_reduce_gemm_exp.py
+++ b/testing/npuir/linalg_ops/test_rank_reduce_gemm_exp.py
@@ -1,0 +1,93 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("gemm"),
+    pytest.mark.mode("Expert"),
+]
+
+
+@tilelang.jit(
+    out_idx=[-1],
+    target="npuir",
+    pass_configs={
+        tilelang.PassConfigKey.NPUIR_ENABLE_AUTO_MULTI_BUFFER: False,
+    },
+)
+def matmul(M, N, K, block_M, block_N, block_K, in_dtype, out_dtype, num_stages):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    multi_l1 = 2
+    multi_l0 = 1
+
+    @T.prim_func
+    def sliceGemmExp(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor((K, N), in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(m_num * n_num, is_npu=True) as (cid, _):
+            bx = cid // n_num * block_M
+            by = cid % n_num * block_N
+
+            A_buf = T.alloc_L1((multi_l1, block_M, block_K), in_dtype)
+            B_buf = T.alloc_L1((multi_l1, block_K, block_N), in_dtype)
+            C_buf = T.alloc_L0C((multi_l0, block_M, block_N), out_dtype)
+
+            for ki in T.serial(T.ceildiv(K, block_K)):
+                offset_k = ki * block_K
+                T.copy(
+                    A[bx : bx + block_M, offset_k : offset_k + block_K],
+                    A_buf[ki % multi_l1, :, :],
+                )
+                T.copy(
+                    B[offset_k : offset_k + block_K, by : by + block_N],
+                    B_buf[ki % multi_l1, :, :],
+                )
+
+                T.gemm(
+                    A_buf[ki % multi_l1, :, :],
+                    B_buf[ki % multi_l1, :, :],
+                    C_buf[0, :, :],
+                    initC=ki == 0,
+                    b_transpose=False,
+                )
+
+                T.copy(C_buf[0, :, :], C[bx : bx + block_M, by : by + block_N])
+
+    return sliceGemmExp
+
+
+DTYPE_CASES = [("float16", "float32")]
+
+
+@pytest.mark.parametrize("in_dtype,out_dtype", DTYPE_CASES)
+def test_matmul_exp(in_dtype, out_dtype):
+    M, K, N = 256, 512, 256
+    A = gen_tensor((M, K), in_dtype, kind="randn")
+    B = gen_tensor((K, N), in_dtype, kind="randn")
+    ref_C = torch.matmul(A, B).to(torch.float32)
+
+    kernel = matmul(
+        M=M,
+        N=N,
+        K=K,
+        block_M=32,
+        block_K=32,
+        block_N=32,
+        in_dtype=in_dtype,
+        out_dtype=out_dtype,
+        num_stages=0,
+    )
+    C = kernel(A, B)
+
+    assert_close(C, ref_C, dtype=out_dtype, rtol=1e-2, atol=1e-2)

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -361,7 +361,7 @@ class KernelCache:
                 self._memory_cache[_key] = disk_hit
                 return disk_hit
 
-        kernel = compiler_npu().compile(func, out_idx)
+        kernel = compiler_npu().compile(func, out_idx, pass_configs=pass_configs)
 
         if env.is_cache_enabled():
             self.save_compile_result(_key, kernel, verbose=verbose)

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -118,7 +118,8 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
         mod = tilelang.transform.NpuLoopVectorize()(mod)
         if need_npuir_bf16_legalize(target=target):
             mod = tilelang.transform.LegalizeNpuirBF16()(mod)
-        mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
+        if pass_ctx.config.get("tl.enable_plan_and_update_buffer_allocation", True):
+            mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
         mod = tir.transform.LowerOpaqueBlock()(mod)
         mod = tilelang.transform.LowerNpuirBlock()(mod)
         mod = tir.transform.RemoveNoOp()(mod)

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -21,8 +21,10 @@ from ..utils import (
 
 from tvm import tir
 from tvm.tir import PrimFunc
+from tvm import transform
 
 from tilelang.profiler import Profiler, TensorSupplyType
+from tilelang.transform.pass_config import normalize_pass_configs
 
 
 class LaunchThreadExtractor:
@@ -1143,7 +1145,9 @@ class compiler_npu:
                 continue
         return default
 
-    def compile(self, mod: PrimFunc, out_idx=None) -> JitKernel_NPU:
+    def compile(
+        self, mod: PrimFunc, out_idx=None, pass_configs: dict[str, Any] = None
+    ) -> JitKernel_NPU:
         self.original_mod = mod
         # extract_param_info
         param_info = self._extract_param_info(mod, out_idx)
@@ -1162,7 +1166,13 @@ class compiler_npu:
         self.out_idx = out_idx
         self.metadata["out_idx"] = self.out_idx
 
-        mlir_path = lower(self.mod)
+        # Apply pass_configs using TVM PassContext
+        if pass_configs is None:
+            pass_configs = {}
+        # Store pass_configs for later use in NPU compilation
+        self.pass_configs = normalize_pass_configs(pass_configs)
+        with transform.PassContext(opt_level=3, config=pass_configs):
+            mlir_path = lower(self.mod)
         if mlir_path.endswith(".mlir"):
             self.mlir_content = self._read_mlir_file(mlir_path)
         else:
@@ -1439,11 +1449,34 @@ class compiler_npu:
             npu_compiler_path = get_npucompiler_path()
             # TileLang Ascend JIT Runtime now follows Triton JIT style.
             # bishengir-compile --enable-triton-kernel-compile=true make sure the way.
-            _compile_option_list = [
-                "--enable-auto-multi-buffer=true",
-                "--enable-triton-kernel-compile=true",
-                "--enable-hivm-compile=true",
-            ]
+
+            # Build compile options with pass_configs support
+            _compile_option_list = []
+
+            # Get configuration from pass_configs with default values
+            pass_configs = getattr(self, "pass_configs", {})
+
+            # Handle --enable-auto-multi-buffer option
+            enable_auto_multi_buffer = pass_configs.get(
+                "npuir.enable_auto_multi_buffer",
+                True,  # Default: enabled
+            )
+            _compile_option_list.append(
+                f"--enable-auto-multi-buffer={str(enable_auto_multi_buffer).lower()}"
+            )
+
+            # Handle --disable-hivm-auto-inject-sync option
+            disable_hivm_auto_inject_sync = pass_configs.get(
+                "npuir.disable_hivm_auto_inject_sync",
+                False,  # Default: enabled
+            )
+            _compile_option_list.append(
+                f"--disable-hivm-auto-inject-sync={str(disable_hivm_auto_inject_sync).lower()}"
+            )
+
+            _compile_option_list.append("--enable-triton-kernel-compile=true")
+
+            _compile_option_list.append("--enable-hivm-compile=true")
 
             TILELANG_ASCEND_MODE = os.environ.get("TILELANG_ASCEND_MODE")
             if TILELANG_ASCEND_MODE is None or TILELANG_ASCEND_MODE.lower().strip() in [

--- a/tilelang/language/customize_npuir.py
+++ b/tilelang/language/customize_npuir.py
@@ -542,8 +542,8 @@ def npuir_dot(
         C_extent = _get_extent(C)
     else:
         assert len(size) == 3, "size must contains [m, k, n]"
-        A_extent = [size[0], size[1]]
-        B_extent = [size[1], size[2]]
+        A_extent = [size[1], size[0]] if a_transpose else [size[0], size[1]]
+        B_extent = [size[2], size[1]] if b_transpose else [size[1], size[2]]
         C_extent = [size[0], size[2]]
 
     A = _to_region(A, "r", A_extent)

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -3,10 +3,12 @@
 # TODO: Add more documentation for each pass config
 
 from enum import Enum
+from typing import Any
 
 
 class PassConfigKey(str, Enum):
     """Pass configuration keys for TileLang compiler."""
+
     # TileLang specific configs
     TL_SIMPLIFY = "tl.Simplify"
     """Enable/disable TileLang simplification passes. Default: True"""
@@ -29,8 +31,21 @@ class PassConfigKey(str, Enum):
     TL_DISABLE_SAFE_MEMORY_ACCESS = "tl.disable_safe_memory_legalize"
     """Disable safe memory access optimization. Default: False"""
 
-    TL_DEBUG_MERGE_SHARED_MEMORY_ALLOCATIONS = "tl.debug_merge_shared_memory_allocations"
+    TL_DEBUG_MERGE_SHARED_MEMORY_ALLOCATIONS = (
+        "tl.debug_merge_shared_memory_allocations"
+    )
     """Enable debug information for merge shared memory allocations. Default: False"""
+
+    NPUIR_ENABLE_AUTO_MULTI_BUFFER = "npuir.enable_auto_multi_buffer"
+    """Enable automatic multi-buffer optimization for hiding memory latency. Default: True"""
+
+    NPUIR_DISABLE_HIVM_AUTO_INJECT_SYNC = "npuir.disable_hivm_auto_inject_sync"
+    """Disable automatic inner core synchronization injection. Default: False"""
+
+    TL_ENABLE_PLAN_AND_UPDATE_BUFFER_ALLOCATION = (
+        "tl.enable_plan_and_update_buffer_allocation"
+    )
+    """Enable advanced buffer allocation planning to optimize memory usage. Default: True"""
 
     # TIR related configs
     TIR_ENABLE_EQUIV_TERMS_IN_CSE = "tir.enable_equiv_terms_in_cse_tir"
@@ -65,3 +80,23 @@ class PassConfigKey(str, Enum):
 
     CUDA_KERNELS_OUTPUT_DIR = "cuda.kernels_output_dir"
     """Output directory for generated CUDA kernels. Default: empty string"""
+
+
+def normalize_pass_configs(pass_configs: dict[str, Any] | None) -> dict[str, Any]:
+    """Canonicalize known pass-config keys and emit compatibility warnings."""
+    if pass_configs is None:
+        return {}
+
+    normalized: dict[str, Any] = {}
+
+    for key, value in pass_configs.items():
+        normalized_key = key
+        if isinstance(key, str):
+            try:
+                normalized_key = PassConfigKey(key)
+            except ValueError:
+                normalized_key = key
+
+        normalized[normalized_key] = value
+
+    return normalized


### PR DESCRIPTION
1. Support the param `pass_configs` in `tilelang.jit`, so that users can decide whether to use specific passes or compilation options of bishengir-compile.
2. Support to automatically do rank reduce in `T.gemm`. However, the operator that uses this feature must set `tl.enable_auto_multi_buffer` to `False` in `pass_configs` of `tilelang.jit`.