### PR TITLE
[AscendNPU IR][Develop] Support DeepSeek-V4 Sparse Attn Bwd kernel

### DIFF
--- a/.github/workflows/ci_npuir.yml
+++ b/.github/workflows/ci_npuir.yml
@@ -141,6 +141,7 @@ jobs:
           examples/sparse_mla_fwd_dynamic_shape.py
           examples/deepseek_v4/engram/engram_gate_kernel_bwd.py
           examples/deepseek_v4/engram/engram_gate_kernel_fwd.py
+          examples/deepseek_v4/example_sparse_attn_bwd_kernel.py
           examples/norm/layer_norm.py
         )
 

--- a/examples/deepseek_v4/example_sparse_attn_bwd_kernel.py
+++ b/examples/deepseek_v4/example_sparse_attn_bwd_kernel.py
@@ -1,0 +1,615 @@
+# ruff: noqa
+# Adapted from miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py for DeepSeek-V4.
+# Key differences from GLM-5:
+#   - attn_sink: gradient computation for learnable per-head scalar
+#   - Single-head KV: kv shape [B, S_kv, D] (no kv_group, no D/D_tail split)
+#   - Index shape: [B, S, topk] (no kv_group dim)
+#   - Outputs: dQ [B, S, H, D], dKV [B, S_kv, D], dAttnSink [H]
+import os
+import tilelang
+import torch
+from tilelang import language as T
+from typing import Optional
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def preprocess(
+    B,
+    S,
+    H,
+    D,
+    block_ND=32,
+    num_stages=5,
+    dtype="bfloat16",
+    accum_dtype="float32",
+):
+    assert dtype == "bfloat16"
+    assert accum_dtype == "float32"
+    shape = [B, S, H, D]
+    num = T.ceildiv(S, block_ND)
+
+    @T.prim_func
+    def preprocess_kernel(
+        O: T.Tensor(shape, dtype),
+        dO: T.Tensor(shape, dtype),
+        Delta: T.Tensor([B, S, H], accum_dtype),
+    ):
+        with T.Kernel(H * num * B, is_npu=True) as (cid, _):
+            bx = cid % H
+            by = (cid // H) % num
+            bz = cid // (H * num)
+            o = T.alloc_fragment([block_ND, block_ND], accum_dtype)
+            do = T.alloc_fragment([block_ND, block_ND], accum_dtype)
+            delta = T.alloc_fragment([block_ND, 1], accum_dtype)
+            acc = T.alloc_fragment([block_ND, block_ND], accum_dtype)
+            T.clear(acc)
+            for k in T.Pipelined(T.ceildiv(D, block_ND), num_stages=num_stages):
+                T.copy(
+                    O[
+                        bz,
+                        by * block_ND : (by + 1) * block_ND,
+                        bx,
+                        k * block_ND : (k + 1) * block_ND,
+                    ],
+                    o,
+                )
+                T.copy(
+                    dO[
+                        bz,
+                        by * block_ND : (by + 1) * block_ND,
+                        bx,
+                        k * block_ND : (k + 1) * block_ND,
+                    ],
+                    do,
+                )
+                for i, j in T.Parallel(block_ND, block_ND):
+                    acc[i, j] += o[i, j] * do[i, j]
+            T.reduce_sum(acc, delta, 1)
+            T.copy(delta[:, 0], Delta[bz, by * block_ND : (by + 1) * block_ND, bx])
+
+    return preprocess_kernel
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def postprocess(
+    B,
+    S_kv,
+    D,
+    block_N=64,
+    dtype="bfloat16",
+    accum_dtype="float32",
+):
+    assert dtype == "bfloat16"
+    assert accum_dtype == "float32"
+    dkv_shape = [B, S_kv, D]
+    num = T.ceildiv(S_kv, block_N)
+
+    @T.prim_func
+    def postprocess_kernel(
+        dKV: T.Tensor(dkv_shape, accum_dtype),
+        dKV_out: T.Tensor(dkv_shape, dtype),
+    ):
+        with T.Kernel(num * B, is_npu=True) as (cid, _):
+            by = cid // num
+            bx = cid % num
+            dKV_shared = T.alloc_shared([block_N, D], accum_dtype)
+            T.copy(dKV[by, bx * block_N : (bx + 1) * block_N, :], dKV_shared)
+            T.copy(dKV_shared, dKV_out[by, bx * block_N : (bx + 1) * block_N, :])
+
+    return postprocess_kernel
+
+
+def next_power_of_2(x: int) -> int:
+    if x <= 1:
+        return 1
+    return 1 << (x - 1).bit_length()
+
+
+@tilelang.jit(target="npuir")
+def bwd(
+    B,
+    S,
+    S_kv,
+    H,
+    D,
+    topk,
+    sm_scale=None,
+    block_size=16,
+    num_stages=0,
+    indices_dtype="int32",
+    dtype="bfloat16",
+    accum_dtype="float32",
+):
+    assert topk % block_size == 0, (
+        f"topk ({topk}) must be divisible by block_size ({block_size})"
+    )
+    assert dtype == "bfloat16"
+    assert accum_dtype == "float32"
+
+    if sm_scale is None:
+        sm_scale = D ** (-0.5)
+    sm_scale_mul_reciprocal_log2 = sm_scale * 1.44269504  # log2(e)
+
+    q_shape = [B, S, H, D]
+    kv_shape = [B, S_kv, D]
+    o_shape = [B, S, H, D]
+    indices_shape = [B, S, topk]
+    delta_shape = [B, S, H]
+    lse_shape = [B, S, H]
+    attn_sink_shape = [H]
+
+    padded_H = max(next_power_of_2(H), 8)
+    block_H = min(32, padded_H)
+    assert padded_H % block_H == 0
+    NH = padded_H // block_H
+    BS = block_size
+    NS = tilelang.cdiv(topk, block_size)
+
+    split_store = 2
+
+    @T.prim_func
+    def sparse_mqa_bwd_kernel(
+        Q: T.Tensor(q_shape, dtype),
+        KV: T.Tensor(kv_shape, dtype),
+        dO: T.Tensor(o_shape, dtype),
+        AttnSink: T.Tensor(attn_sink_shape, accum_dtype),
+        Indices: T.Tensor(indices_shape, indices_dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+        Delta: T.Tensor(delta_shape, accum_dtype),
+        dQ: T.Tensor(q_shape, dtype),
+        dKV: T.Tensor(kv_shape, accum_dtype),
+        dAttnSink: T.Tensor(attn_sink_shape, accum_dtype),
+    ):
+        with T.Kernel(S * B * NH, is_npu=True) as (cid, _):
+            s_i = cid % S
+            by = (cid // S) % B
+            bz = cid // (S * B)
+            Q_shared = T.alloc_shared([block_H, D], dtype)
+            KV_shared = T.alloc_shared([BS, D], dtype)
+            dO_shared = T.alloc_shared([block_H, D], dtype)
+            mask = T.alloc_fragment([BS], "bool")
+            idxs = T.alloc_fragment([BS], indices_dtype)
+            idxs_cmp = T.alloc_fragment([BS], indices_dtype)
+
+            P_shared_cast = T.alloc_shared([block_H, BS], dtype)
+            dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
+            dQ_shared = T.alloc_shared([block_H, D], dtype)
+
+            acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
+            tmp_p = T.alloc_fragment([block_H, BS], accum_dtype)
+            acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
+            acc_dq = T.alloc_fragment([block_H, D], accum_dtype)
+            acc_dkv = T.alloc_fragment([BS, D], accum_dtype)
+            acc_dkv_shared = T.alloc_fragment([BS, D], accum_dtype)
+
+            Delta_shared = T.alloc_shared([block_H], accum_dtype)
+            AttnSink_shared = T.alloc_shared([block_H], accum_dtype)
+            tmp_AttnSink = T.alloc_shared([block_H], accum_dtype)
+            Lse_shared = T.alloc_shared([block_H], accum_dtype)
+
+            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
+            T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
+            T.copy(Delta[by, s_i, bz * block_H : (bz + 1) * block_H], Delta_shared)
+            T.copy(Lse[by, s_i, bz * block_H : (bz + 1) * block_H], Lse_shared)
+
+            T.clear(acc_dq)
+
+            acc_p_inf = -T.infinity(accum_dtype)
+            value_negone = -1
+
+            T.vbrc(value_negone, idxs_cmp)
+
+            for i_i in T.Pipelined(NS, num_stages=num_stages):
+                T.copy(Indices[by, s_i, i_i * BS], idxs, size=[BS])
+                T.vcmp(idxs, idxs_cmp, mask, "ne")
+                T.clear(KV_shared)
+                for h_i, bi_i in T.Parallel(block_H, BS):
+                    acc_p[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, acc_p_inf)
+                for i in T.serial(BS):
+                    cur_idx = idxs[i]
+                    if cur_idx != -1:
+                        T.copy(KV[by, cur_idx, 0], KV_shared[i, 0], size=[1, D])
+
+                T.gemm(Q_shared, KV_shared, acc_p, b_transpose=True)
+
+                # P = exp2(scores * sm_scale_log2e - LSE)
+                for h_i, bi_i in T.Parallel(block_H, BS):
+                    acc_p[h_i, bi_i] = (
+                        acc_p[h_i, bi_i] * sm_scale_mul_reciprocal_log2
+                        - Lse_shared[h_i]
+                    )
+
+                T.vexp2(acc_p, acc_p, tmp_p)
+                T.copy(acc_p, P_shared_cast)
+
+                # dP = P * (dO @ KV^T - Delta)
+                T.gemm(dO_shared, KV_shared, acc_dp, b_transpose=True, initC=True)
+
+                for h_i, bi_i in T.Parallel(block_H, BS):
+                    acc_dp[h_i, bi_i] = (
+                        acc_p[h_i, bi_i]
+                        * (acc_dp[h_i, bi_i] - Delta_shared[h_i])
+                        * sm_scale
+                    )
+
+                T.copy(acc_dp, dP_shared_cast)
+
+                # dQ += dP @ KV
+                T.gemm(dP_shared_cast, KV_shared, acc_dq)
+
+                # dKV += dP^T @ Q + P^T @ dO
+                T.gemm(dP_shared_cast, Q_shared, acc_dkv, a_transpose=True, initC=True)
+                T.gemm(
+                    P_shared_cast,
+                    dO_shared,
+                    acc_dkv_shared,
+                    a_transpose=True,
+                    initC=True,
+                )
+                T.vadd(acc_dkv, acc_dkv_shared, acc_dkv)
+
+                # Atomic store dKV with split to reduce register pressure
+                for s in T.serial(split_store):
+                    for bi_i in T.serial(BS // split_store):
+                        row = bi_i + s * (BS // split_store)
+                        cur_idx = idxs[row]
+                        if cur_idx != -1:
+                            T.atomic_add(dKV[by, cur_idx, :], acc_dkv[row, :])
+
+            # Store dQ
+            T.copy(acc_dq, dQ_shared)
+            T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
+            # dAttnSink[h] = -sum_{b,s}( Delta[b,s,h] * p_sink[b,s,h] )
+            # where p_sink = exp(attn_sink[h]) / Z = exp2(attn_sink[h]*log2e - LSE)
+            # attn_sink is a pre-scaled logit, so only convert to log2 base (no sm_scale)
+            T.copy(AttnSink[bz * block_H : (bz + 1) * block_H], AttnSink_shared)
+            T.vmul(AttnSink_shared, 1.44269504, AttnSink_shared)
+            T.vsub(AttnSink_shared, Lse_shared, AttnSink_shared)
+            T.vexp2(AttnSink_shared, AttnSink_shared, tmp_AttnSink)
+            T.vmul(AttnSink_shared, Delta_shared, AttnSink_shared)
+            T.vmul(AttnSink_shared, -1, AttnSink_shared)
+            T.atomic_add(dAttnSink[bz * block_H : (bz + 1) * block_H], AttnSink_shared)
+
+    return sparse_mqa_bwd_kernel
+
+
+def sparse_mqa_bwd_interface(q, kv, attn_sink, o, do, topk_idxs, lse, sm_scale):
+    """Backward interface for V4 sparse MQA attention.
+    Args:
+        q:         [B, S, H, D] bf16
+        kv:        [B, S_kv, D] bf16
+        attn_sink: [H] fp32
+        o:         [B, S, H, D] bf16 (forward output)
+        do:        [B, S, H, D] bf16 (grad of output)
+        topk_idxs: [B, S, topk] int32
+        lse:       [B, S, H] fp32 (log-sum-exp from forward)
+        sm_scale:  float or None
+    Returns:
+        dq:         [B, S, H, D] bf16
+        dkv:        [B, S_kv, D] bf16
+        d_attn_sink: [H] fp32
+    """
+    assert q.is_contiguous() and kv.is_contiguous()
+    assert topk_idxs.is_contiguous() and lse.is_contiguous()
+    B, S, H, D = q.shape
+    _, S_kv, _ = kv.shape
+    topk = topk_idxs.shape[-1]
+
+    # Pad topk to next multiple of block_size (kernel requires divisibility)
+    block_size = 16
+    padded_topk = (topk + block_size - 1) // block_size * block_size
+    if padded_topk != topk:
+        pad = torch.full(
+            (B, S, padded_topk - topk),
+            -1,
+            device=topk_idxs.device,
+            dtype=topk_idxs.dtype,
+        )
+        topk_idxs = torch.cat([topk_idxs, pad], dim=-1).contiguous()
+        topk = padded_topk
+
+    preprocess_kernel = preprocess(B, S, H, D)
+    bwd_kernel = bwd(B, S, S_kv, H, D, topk, sm_scale, block_size)
+    postprocess_kernel = postprocess(B, S_kv, D, block_N=16)
+
+    delta = preprocess_kernel(o, do)
+    dkv = torch.zeros_like(kv, dtype=torch.float32)
+    d_attn_sink = torch.zeros_like(attn_sink)
+    dq = torch.zeros_like(q, dtype=torch.bfloat16)
+    bwd_kernel(q, kv, do, attn_sink, topk_idxs, lse, delta, dq, dkv, d_attn_sink)
+
+    dkv = postprocess_kernel(dkv)
+
+    return dq, dkv, d_attn_sink
+
+
+LOG2E = 1.4426950408889634
+
+
+def gather_sparse_kv(kv: torch.Tensor, topk_idxs: torch.Tensor):
+    """
+    kv:        [B, S_kv, D]
+    topk_idxs: [B, S, topk], may contain -1
+
+    return:
+        kv_sparse: [B, S, topk, D]
+        valid_mask: [B, S, topk]
+    """
+    B, S, topk = topk_idxs.shape
+
+    valid_mask = topk_idxs != -1
+    safe_idxs = topk_idxs.masked_fill(~valid_mask, 0).long()
+
+    batch_idx = torch.arange(B, device=kv.device).view(B, 1, 1).expand(B, S, topk)
+    kv_sparse = kv[batch_idx, safe_idxs, :]
+
+    kv_sparse = kv_sparse * valid_mask.unsqueeze(-1).to(kv_sparse.dtype)
+    return kv_sparse, valid_mask
+
+
+def ref_sparse_attn_with_lse(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    sm_scale: Optional[float] = None,
+):
+    """
+    PyTorch reference forward.
+
+    q:         [B, S, H, D], bf16
+    kv:        [B, S_kv, D], bf16
+    attn_sink: [H], fp32
+    topk_idxs: [B, S, topk], int32
+
+    Returns:
+        o:        [B, S, H, D], fp32
+        lse_log2: [B, S, H], fp32
+
+    Note:
+        The returned lse_log2 is the log2-space LSE used by the backward kernel.
+    """
+    q = q.float()
+    kv = kv.float()
+    attn_sink = attn_sink.float()
+
+    B, S, H, D = q.shape
+    topk = topk_idxs.shape[-1]
+
+    if sm_scale is None:
+        sm_scale = D**-0.5
+
+    kv_sparse, valid_mask = gather_sparse_kv(kv, topk_idxs)
+
+    # scores: [B, S, H, topk]
+    scores = torch.einsum("bshd,bskd->bshk", q, kv_sparse) * sm_scale
+    scores = scores.masked_fill(~valid_mask.unsqueeze(2), float("-inf"))
+
+    scores_max = scores.max(dim=-1, keepdim=True).values
+    scores_max = scores_max.clamp(min=-1e30)
+
+    exp_scores = torch.exp(scores - scores_max)
+    numerator = torch.einsum("bshk,bskd->bshd", exp_scores, kv_sparse)
+    sum_exp = exp_scores.sum(dim=-1)
+
+    sink_term = torch.exp(attn_sink.view(1, 1, H) - scores_max.squeeze(-1))
+    denominator = sum_exp + sink_term
+    o = numerator / denominator.unsqueeze(-1)
+
+    # The backward kernel uses exp2(score * sm_scale * log2e - Lse),
+    # so this Lse must be in log2 space:
+    # lse_log2 = log2(sum_exp_shifted + sink_shifted) + max_scaled * log2e
+    lse_log2 = torch.log2(denominator) + scores_max.squeeze(-1) * LOG2E
+
+    return o, lse_log2
+
+
+def ref_sparse_attn_with_grad(
+    q_base: torch.Tensor,
+    kv_base: torch.Tensor,
+    attn_sink_base: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    do: torch.Tensor,
+    sm_scale: Optional[float] = None,
+):
+    """
+    Compute reference gradients with PyTorch autograd.
+
+    do is the externally provided output gradient.
+    This is more general than loss=o.sum(), and is equivalent to:
+        loss = (o * do).sum()
+    """
+    q_ref = q_base.detach().clone().float().requires_grad_(True)
+    kv_ref = kv_base.detach().clone().float().requires_grad_(True)
+    sink_ref = attn_sink_base.detach().clone().float().requires_grad_(True)
+
+    o_ref, lse_ref = ref_sparse_attn_with_lse(
+        q_ref,
+        kv_ref,
+        sink_ref,
+        topk_idxs,
+        sm_scale,
+    )
+
+    loss = (o_ref * do.float()).sum()
+    loss.backward()
+
+    return {
+        "o": o_ref.detach(),
+        "lse": lse_ref.detach(),
+        "dq": q_ref.grad.detach(),
+        "dkv": kv_ref.grad.detach(),
+        "d_attn_sink": sink_ref.grad.detach(),
+    }
+
+
+def make_inputs(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    dim: int,
+    seq_len_kv: int,
+    topk: int,
+    seed: int = 88888888,
+    device: str = "npu",
+    use_invalid_indices: bool = False,
+    topk_mode: str = "no_conflict",
+):
+    torch.manual_seed(seed)
+
+    q = torch.randn(
+        batch_size,
+        seq_len,
+        num_heads,
+        dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    kv = torch.randn(
+        batch_size,
+        seq_len_kv,
+        dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    attn_sink = torch.randn(
+        num_heads,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    if topk_mode == "no_conflict":
+        assert seq_len * topk <= seq_len_kv
+        topk_idxs = torch.empty(
+            batch_size, seq_len, topk, device=device, dtype=torch.int32
+        )
+        for b in range(batch_size):
+            for s in range(seq_len):
+                start = s * topk
+                topk_idxs[b, s, :] = torch.arange(
+                    start, start + topk, device=device, dtype=torch.int32
+                )
+    elif topk_mode == "conflict":
+        topk_idxs = torch.arange(topk, device=device, dtype=torch.int32).view(
+            1, 1, topk
+        )
+        topk_idxs = topk_idxs.expand(batch_size, seq_len, topk).contiguous()
+    elif topk_mode == "random":
+        topk_idxs = torch.randint(
+            low=0,
+            high=seq_len_kv,
+            size=(batch_size, seq_len, topk),
+            device=device,
+            dtype=torch.int32,
+        )
+    elif topk_mode == "duplicate":
+        topk_idxs = torch.zeros(
+            batch_size,
+            seq_len_kv,
+            topk,
+            device=device,
+            dtype=torch.int32,
+        )
+
+    sm_scale = dim**-0.5
+
+    return (
+        q.contiguous(),
+        kv.contiguous(),
+        attn_sink.contiguous(),
+        topk_idxs.contiguous(),
+        sm_scale,
+    )
+
+
+def run_one_bwd_case(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    dim: int,
+    seq_len_kv: int,
+    topk: int,
+    topk_mode: str = "no_conflict",
+):
+    print(
+        f"\n[BWD] "
+        f"B={batch_size}, S={seq_len}, H={num_heads}, D={dim}, "
+        f"S_kv={seq_len_kv}, topk={topk}, topk_mode={topk_mode}"
+    )
+
+    q, kv, attn_sink, topk_idxs, sm_scale = make_inputs(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        num_heads=num_heads,
+        dim=dim,
+        seq_len_kv=seq_len_kv,
+        topk=topk,
+        topk_mode=topk_mode,
+    )
+
+    # Construct external gradient do.
+    torch.manual_seed(1234)
+    do = torch.randn_like(q, dtype=torch.bfloat16).contiguous()
+
+    print("topk_idxs", topk_idxs)
+    # 1. PyTorch reference forward + backward
+    ref = ref_sparse_attn_with_grad(
+        q_base=q,
+        kv_base=kv,
+        attn_sink_base=attn_sink,
+        topk_idxs=topk_idxs,
+        do=do,
+        sm_scale=sm_scale,
+    )
+
+    # 2. TileLang backward pass.
+    # Note: feed reference o/lse to bwd here to validate the backward kernel separately.
+    # Once the forward pass can produce lse, replace this with TileLang forward o/lse.
+    tl_dq, tl_dkv, tl_d_attn_sink = sparse_mqa_bwd_interface(
+        q=q,
+        kv=kv,
+        attn_sink=attn_sink,
+        o=ref["o"].to(torch.bfloat16).contiguous(),
+        do=do,
+        topk_idxs=topk_idxs,
+        lse=ref["lse"].float().contiguous(),
+        sm_scale=sm_scale,
+    )
+
+    # 3. Compare
+    torch.testing.assert_close(tl_dq.float(), ref["dq"].float(), rtol=5e-2, atol=5e-2)
+    print("\033[92mdq check passed.\033[0m")
+    torch.testing.assert_close(
+        tl_d_attn_sink.float(), ref["d_attn_sink"].float(), rtol=5e-2, atol=5e-2
+    )
+    print("\033[92mattn_sink check passed.\033[0m")
+    torch.testing.assert_close(
+        tl_dkv.float(),
+        ref["dkv"].to(torch.bfloat16).float(),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+    print("\033[92mdkv check passed.\033[0m")
+
+
+def run_all_tests():
+    cases = [
+        # (batch, seqlen, heads, dim, seqlen_kv, topk, topk_mode)
+        (1, 128, 8, 512, 160, 64, "random"),
+        (1, 256, 16, 512, 320, 128, "random"),
+        (1, 256, 64, 512, 320, 128, "random"),
+        (2, 128, 8, 512, 160, 64, "random"),
+        (1, 512, 8, 512, 640, 256, "random"),
+        (1, 512, 8, 512, 640, 256, "random"),
+    ]
+    for case in cases:
+        run_one_bwd_case(*case)
+
+
+if __name__ == "__main__":
+    tilelang.cache.clear_cache()
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+
+    run_all_tests()

--- a/examples/deepseek_v4/example_sparse_attn_kernel.py
+++ b/examples/deepseek_v4/example_sparse_attn_kernel.py
@@ -12,12 +12,19 @@ INT32 = "int32"
 
 
 @tilelang.jit(out_idx=[2], target="npuir")
-def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads, dim, max_top_k=640, scale=None,
-                       dtype=FP16, accum_dtype=FP32, indices_dtype=INT32):
-    if scale is None:
-        scale = (1.0 / dim) ** 0.5
-    else:
-        scale = scale
+def sparse_attn_kernel(
+    block_top_k_vec,
+    block_top_k_cube,
+    block_heads,
+    num_heads,
+    dim,
+    max_top_k=640,
+    scale=None,
+    dtype=FP16,
+    accum_dtype=FP32,
+    indices_dtype=INT32,
+):
+    scale = (1.0 / dim) ** 0.5 if scale is None else scale
     batch_size = T.symbolic("batchSize")
     seq_len = T.symbolic("seqLen")
     seq_len_kv = T.symbolic("seqLenKV")
@@ -26,14 +33,16 @@ def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads
 
     @T.prim_func
     def sparseAttn(
-            Q: T.Tensor((batch_size, seq_len, num_heads, dim), dtype),
-            KV: T.Tensor((batch_size, seq_len_kv, dim), dtype),
-            Output: T.Tensor((batch_size, seq_len, num_heads, dim), dtype),
-            AttnSink: T.Tensor((num_heads, 1), accum_dtype),
-            TopKIndices: T.Tensor((batch_size, seq_len, top_k), indices_dtype),
-            SparseKVBuffer: T.Tensor((batch_size, seq_len, top_k_reserved, dim), dtype),
-            ValidMaskBuffer: T.Tensor((batch_size, seq_len, top_k_reserved), accum_dtype),
-            WorkspaceScore: T.Tensor((batch_size, seq_len, block_heads, top_k_reserved), accum_dtype),
+        Q: T.Tensor((batch_size, seq_len, num_heads, dim), dtype),
+        KV: T.Tensor((batch_size, seq_len_kv, dim), dtype),
+        Output: T.Tensor((batch_size, seq_len, num_heads, dim), dtype),
+        AttnSink: T.Tensor((num_heads, 1), accum_dtype),
+        TopKIndices: T.Tensor((batch_size, seq_len, top_k), indices_dtype),
+        SparseKVBuffer: T.Tensor((batch_size, seq_len, top_k_reserved, dim), dtype),
+        ValidMaskBuffer: T.Tensor((batch_size, seq_len, top_k_reserved), accum_dtype),
+        WorkspaceScore: T.Tensor(
+            (batch_size, seq_len, block_heads, top_k_reserved), accum_dtype
+        ),
     ):
         with T.Kernel(batch_size * seq_len, is_npu=True) as (cid, _):
             by = cid // seq_len
@@ -46,7 +55,7 @@ def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads
             o_shared = T.alloc_shared((block_heads, dim), dtype)
             acc_s_cast = T.alloc_shared((block_heads, max_top_k), dtype)
             attn_sink_shared = T.alloc_shared((block_heads, 1), accum_dtype)
-            
+
             idxs = T.alloc_fragment((block_top_k_vec,), indices_dtype)
             acc_s_block = T.alloc_fragment((block_heads, block_top_k_cube), accum_dtype)
             acc_s = T.alloc_fragment((block_heads, max_top_k), accum_dtype)
@@ -60,8 +69,12 @@ def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads
                 T.vbrc(value_zero, acc_o)
                 T.copy(Q[by, bx, n * block_heads, 0], q_shared)
                 if n == 0:
-                    for k in T.Pipelined(T.ceildiv(top_k_reserved, block_top_k_vec), num_stages=2):
-                        real_block_top_k = T.min(top_k - k * block_top_k_vec, block_top_k_vec)
+                    for k in T.Pipelined(
+                        T.ceildiv(top_k_reserved, block_top_k_vec), num_stages=2
+                    ):
+                        real_block_top_k = T.min(
+                            top_k - k * block_top_k_vec, block_top_k_vec
+                        )
                         real_block_top_k = T.max(real_block_top_k, 0)
                         T.copy(TopKIndices[by, bx, k * block_top_k_vec], idxs)
                         T.vbrc(value_zero, valid_mask_block)
@@ -69,24 +82,41 @@ def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads
                         for i in T.serial(real_block_top_k):
                             cur_idx = idxs[i]
                             if cur_idx != -1:
-                                valid_mask_block[i] = 1.
-                                T.copy(KV[by, cur_idx, 0], kv_gather[i, 0], size=[1, dim])
-                        T.copy(valid_mask_block, ValidMaskBuffer[by, bx, k * block_top_k_vec])
-                        T.copy(kv_gather, SparseKVBuffer[by, bx, k * block_top_k_vec, 0])
+                                valid_mask_block[i] = 1.0
+                                T.copy(
+                                    KV[by, cur_idx, 0], kv_gather[i, 0], size=[1, dim]
+                                )
+                        T.copy(
+                            valid_mask_block,
+                            ValidMaskBuffer[by, bx, k * block_top_k_vec],
+                        )
+                        T.copy(
+                            kv_gather, SparseKVBuffer[by, bx, k * block_top_k_vec, 0]
+                        )
 
                 for k in T.Pipelined(T.ceildiv(top_k, block_top_k_cube), num_stages=2):
                     T.copy(SparseKVBuffer[by, bx, k * block_top_k_cube, 0], kv_shared)
-                    T.gemm(q_shared, kv_shared, acc_s_block, initC=True, b_transpose=True)
+                    T.gemm(
+                        q_shared, kv_shared, acc_s_block, initC=True, b_transpose=True
+                    )
                     T.copy(acc_s_block, WorkspaceScore[by, bx, 0, k * block_top_k_cube])
 
-                T.copy(WorkspaceScore[by, bx, 0, 0], acc_s, size=[block_heads, top_k_reserved])
+                T.copy(
+                    WorkspaceScore[by, bx, 0, 0],
+                    acc_s,
+                    size=[block_heads, top_k_reserved],
+                )
                 for i, j in T.Parallel(block_heads, max_top_k):
                     acc_s[i, j] *= scale
                 T.reduce_max(acc_s, scores_max, dim=1, size=[block_heads, top_k])
                 for i, j in T.Parallel(block_heads, max_top_k):
                     acc_s[i, j] = T.exp(acc_s[i, j] - scores_max[i, 0])
                 T.vbrc(value_zero, valid_mask)
-                T.copy(ValidMaskBuffer[by, bx, 0], valid_mask[0, 0], size=[1, top_k_reserved])
+                T.copy(
+                    ValidMaskBuffer[by, bx, 0],
+                    valid_mask[0, 0],
+                    size=[1, top_k_reserved],
+                )
                 for i, j in T.Parallel(block_heads, max_top_k):
                     acc_s[i, j] *= valid_mask[0, j]
                 T.reduce_sum(acc_s, scores_sum, dim=1, size=[block_heads, top_k])
@@ -99,8 +129,13 @@ def sparse_attn_kernel(block_top_k_vec, block_top_k_cube, block_heads, num_heads
 
                 for k in T.Pipelined(T.ceildiv(top_k, block_top_k_cube), num_stages=2):
                     T.copy(SparseKVBuffer[by, bx, k * block_top_k_cube, 0], kv_shared)
-                    T.gemm(acc_s_cast[0, k * block_top_k_cube], kv_shared, acc_o, initC=False,
-                           size=[block_heads, block_top_k_cube, dim])
+                    T.gemm(
+                        acc_s_cast[0, k * block_top_k_cube],
+                        kv_shared,
+                        acc_o,
+                        initC=False,
+                        size=[block_heads, block_top_k_cube, dim],
+                    )
                 T.copy(acc_o, o_shared)
                 T.copy(o_shared, Output[by, bx, n * block_heads, 0])
 
@@ -112,8 +147,11 @@ def next_divisible_number(num, divisor):
 
 
 def sparse_attn(
-        q: torch.Tensor, kv: torch.Tensor, attn_sink: torch.Tensor, topk_idxs: torch.Tensor,
-        softmax_scale: Optional[float] = None
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: Optional[float] = None,
 ):
     block_vec = 32
     block_cube = 128
@@ -121,21 +159,50 @@ def sparse_attn(
     max_top_k = 256
     batch_size, seq_len, num_heads, dim = q.size()
     top_k = topk_idxs.shape[-1]
-    if not hasattr(sparse_attn, 'kernel') or sparse_attn.num_heads != num_heads or sparse_attn.dim != dim:
-        os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
-        bytes_workspace = block_cube * dim * 2 + block_heads * block_cube * 4 * 2 + block_heads * dim * 4
-        os.environ['TILELANG_ASCEND_WORKSPACE_SIZE'] = str(bytes_workspace * 16)
-        sparse_attn.kernel = sparse_attn_kernel(block_vec, block_cube, block_heads, num_heads, dim, max_top_k, softmax_scale)
+    if (
+        not hasattr(sparse_attn, "kernel")
+        or sparse_attn.num_heads != num_heads
+        or sparse_attn.dim != dim
+    ):
+        os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+        bytes_workspace = (
+            block_cube * dim * 2
+            + block_heads * block_cube * 4 * 2
+            + block_heads * dim * 4
+        )
+        os.environ["TILELANG_ASCEND_WORKSPACE_SIZE"] = str(bytes_workspace * 16)
+        sparse_attn.kernel = sparse_attn_kernel(
+            block_vec, block_cube, block_heads, num_heads, dim, max_top_k, softmax_scale
+        )
         sparse_attn.num_heads = num_heads
         sparse_attn.dim = dim
-    output = torch.empty((batch_size, seq_len, num_heads, dim), dtype=q.dtype, device=q.device)
-    sparse_kv_buffer = torch.empty((batch_size, seq_len, next_divisible_number(top_k, block_cube), dim),
-                                   dtype=q.dtype, device=q.device)
-    valid_mask_buffer = torch.empty((batch_size, seq_len, next_divisible_number(top_k, block_cube)),
-                                    dtype=attn_sink.dtype, device=attn_sink.device)
-    workspace_score = torch.empty((batch_size, seq_len, block_heads, next_divisible_number(top_k, block_cube)),
-                                  dtype=attn_sink.dtype, device=attn_sink.device)
-    output = sparse_attn.kernel(q, kv.contiguous(), attn_sink, topk_idxs, sparse_kv_buffer, valid_mask_buffer, workspace_score)
+    output = torch.empty(
+        (batch_size, seq_len, num_heads, dim), dtype=q.dtype, device=q.device
+    )
+    sparse_kv_buffer = torch.empty(
+        (batch_size, seq_len, next_divisible_number(top_k, block_cube), dim),
+        dtype=q.dtype,
+        device=q.device,
+    )
+    valid_mask_buffer = torch.empty(
+        (batch_size, seq_len, next_divisible_number(top_k, block_cube)),
+        dtype=attn_sink.dtype,
+        device=attn_sink.device,
+    )
+    workspace_score = torch.empty(
+        (batch_size, seq_len, block_heads, next_divisible_number(top_k, block_cube)),
+        dtype=attn_sink.dtype,
+        device=attn_sink.device,
+    )
+    output = sparse_attn.kernel(
+        q,
+        kv.contiguous(),
+        attn_sink,
+        topk_idxs,
+        sparse_kv_buffer,
+        valid_mask_buffer,
+        workspace_score,
+    )
     return output
 
 
@@ -158,7 +225,9 @@ def softmax_with_sink(x: torch.Tensor, attn_sink: torch.Tensor, head_dim, dim=-1
     sum_exp = torch.sum(exp_x, dim=dim, keepdim=True)
 
     sink_view_shape = [1] * x.dim()
-    sink_view_shape[head_dim if head_dim > 0 else head_dim % x.dim()] = x.shape[head_dim]
+    sink_view_shape[head_dim if head_dim > 0 else head_dim % x.dim()] = x.shape[
+        head_dim
+    ]
 
     # attention sink
     sink_term = torch.exp(attn_sink.view(sink_view_shape) - max_vals)
@@ -167,20 +236,34 @@ def softmax_with_sink(x: torch.Tensor, attn_sink: torch.Tensor, head_dim, dim=-1
     return exp_x / adjusted_sum
 
 
-def sparse_attn_torch(q: torch.Tensor, kv: torch.Tensor, attn_sink: torch.Tensor, topk_idxs: torch.Tensor,
-                      softmax_scale: Optional[float] = None):
+def sparse_attn_torch(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: Optional[float] = None,
+):
     """Reference Sparse Attention kernel implemented in PyTorch"""
     kv_sparse = gather_from_kv(kv, topk_idxs)
-    mask_acc_s = torch.where((topk_idxs == -1).unsqueeze(-2), -torch.inf, 0.)
+    mask_acc_s = torch.where((topk_idxs == -1).unsqueeze(-2), -torch.inf, 0.0)
     mask_acc_s = mask_acc_s.to(device=q.device, dtype=torch.float32)
-    ref_output = softmax_with_sink(
-        ((q @ kv_sparse.transpose(-2, -1)).to(torch.float32) + mask_acc_s) * softmax_scale, attn_sink, head_dim=-2,
-        dim=-1).to(torch.float16) @ kv_sparse
+    ref_output = (
+        softmax_with_sink(
+            ((q @ kv_sparse.transpose(-2, -1)).to(torch.float32) + mask_acc_s)
+            * softmax_scale,
+            attn_sink,
+            head_dim=-2,
+            dim=-1,
+        ).to(torch.float16)
+        @ kv_sparse
+    )
 
     return ref_output
 
 
-def rand_sparse_attn_input(batch_size, num_heads, seq_len, seq_len_kv, top_k, dim, seed=88888888, causal=True):
+def rand_sparse_attn_input(
+    batch_size, num_heads, seq_len, seq_len_kv, top_k, dim, seed=88888888, causal=True
+):
     """Generate legalized random inputs for Sparse Attention"""
     torch.manual_seed(seed)
 
@@ -188,7 +271,9 @@ def rand_sparse_attn_input(batch_size, num_heads, seq_len, seq_len_kv, top_k, di
     q = torch.randn((batch_size, seq_len, num_heads, dim), dtype=torch.float16).npu()
     kv = torch.randn((batch_size, seq_len_kv, dim), dtype=torch.float16).npu()
     attn_sink = torch.randn((num_heads,), dtype=torch.float32).npu()
-    top_k_indices = torch.randint(low=0, high=seq_len_kv, size=(batch_size, seq_len, top_k), dtype=torch.int32).npu()
+    top_k_indices = torch.randint(
+        low=0, high=seq_len_kv, size=(batch_size, seq_len, top_k), dtype=torch.int32
+    ).npu()
 
     if causal:
         # Apply causal mask on top_k_indices
@@ -201,18 +286,18 @@ def rand_sparse_attn_input(batch_size, num_heads, seq_len, seq_len_kv, top_k, di
     scale = (1.0 / dim) ** 0.5
 
     return {
-        'q': q,
-        'kv': kv,
-        'attn_sink': attn_sink,
-        'topk_idxs': top_k_indices,
-        'softmax_scale': scale,
+        "q": q,
+        "kv": kv,
+        "attn_sink": attn_sink,
+        "topk_idxs": top_k_indices,
+        "softmax_scale": scale,
     }
 
 
 def generate_and_save_data(case_id, **kwargs):
     inputs = rand_sparse_attn_input(**kwargs)
     outputs = sparse_attn_torch(**inputs)
-    torch.save({'inputs': inputs, 'outputs': outputs}, f"case_{case_id}.pt")
+    torch.save({"inputs": inputs, "outputs": outputs}, f"case_{case_id}.pt")
 
 
 def generate_data():
@@ -228,11 +313,11 @@ def generate_data():
 
 
 def run_test():
-    data = torch.load("case_0.pt", map_location=torch.device('npu'))
-    output = sparse_attn(**data['inputs'])
+    data = torch.load("case_0.pt", map_location=torch.device("npu"))
+    output = sparse_attn(**data["inputs"])
     print(output)
-    torch.testing.assert_close(data['outputs'], output, rtol=1e-2, atol=1e-2)
-    print('\033[92mAll check passed.\033[0m')
+    torch.testing.assert_close(data["outputs"], output, rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed.\033[0m")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
tilelang_sparse_mla_bwd.py for DeepSeek-V4
1. torch_reference o/lse is used to feed bwd, to verify bwd kernel independently.
Once fwd can return lse, replace with tilelang fwd's o/lse.
2. NPU bwd is bf16 + atomic add，tolerance 5e-2, keeping the same as the GPU version.
