### PR TITLE
[TVM] Remove redundant cast for bfloat16; Support complex scenarios

### DIFF
--- a/src/transform/legalize_npuir_bf16.cc
+++ b/src/transform/legalize_npuir_bf16.cc
@@ -12,6 +12,7 @@
 #include <tvm/tir/transform.h>
 
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -40,6 +41,8 @@ private:
   struct PreparedRegion {
     PrimExpr region;
     Array<Stmt> prefix;
+    Buffer temp_fp32;
+    bool needs_cast_back = false;
   };
 
   struct CachedSourceCast {
@@ -49,6 +52,13 @@ private:
     Buffer temp_f32;
   };
 
+  // Map: real_bf16_buffer -> temp_fp32_buffer
+  std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>
+      bf16_to_fp32_alias_;
+
+  std::vector<std::vector<Buffer>> block_temp_buffers_;
+  std::vector<std::vector<CachedSourceCast>> block_source_cast_cache_;
+
   bool IsBF16(const Buffer &buffer) const {
     return buffer.defined() && buffer->dtype == DataType::BFloat(16);
   }
@@ -57,9 +67,9 @@ private:
     if (call == nullptr) {
       return false;
     }
-    std::vector<std::string> binary_ops = {"tl.npuir_add", "tl.npuir_mul",
-                                           "tl.npuir_max", "tl.npuir_min",
-                                           "tl.npuir_div", "tl.npuir_sub"};
+    std::vector<std::string> binary_ops = {
+        "tl.npuir_add", "tl.npuir_mul", "tl.npuir_max", "tl.npuir_min",
+        "tl.npuir_div", "tl.npuir_sub", "tl.npuir_cmp"};
     return std::any_of(binary_ops.begin(), binary_ops.end(),
                        [&](const std::string &op_name) {
                          return call->op.same_as(Op::Get(op_name));
@@ -71,8 +81,9 @@ private:
       return false;
     }
     std::vector<std::string> unary_ops = {
-        "tl.npuir_exp",  "tl.npuir_relu",  "tl.npuir_sigmoid", "tl.npuir_ln",
-        "tl.npuir_sqrt", "tl.npuir_rsqrt", "tl.npuir_abs",     "tl.npuir_rec"};
+        "tl.npuir_exp", "tl.npuir_relu", "tl.npuir_sigmoid",
+        "tl.npuir_ln",  "tl.npuir_sqrt", "tl.npuir_rsqrt",
+        "tl.npuir_abs", "tl.npuir_rec",  "tl.npuir_reduce"};
     return std::any_of(unary_ops.begin(), unary_ops.end(),
                        [&](const std::string &op_name) {
                          return call->op.same_as(Op::Get(op_name));
@@ -119,6 +130,16 @@ private:
   }
 
   PreparedRegion PrepareSourceRegion(const RegionOp &src, const String &scope) {
+    const Buffer &src_buf = src.GetBuffer();
+    // If this buffer is currently aliased to a temp FP32 buffer, use it
+    // directly
+    auto it = bf16_to_fp32_alias_.find(src_buf);
+    if (it != bf16_to_fp32_alias_.end()) {
+      PreparedRegion prepared{
+          CreateRegion(it->second, src.GetRanges(), /*access_mask=*/1), {}};
+      return prepared;
+    }
+
     PreparedRegion prepared{
         CreateRegion(src.GetBuffer(), src.GetRanges(), /*access_mask=*/1), {}};
     if (!IsBF16(src.GetBuffer())) {
@@ -149,19 +170,29 @@ private:
   }
 
   PreparedRegion PrepareDestinationRegion(const RegionOp &dst) {
-    PreparedRegion prepared{
-        CreateRegion(dst.GetBuffer(), dst.GetRanges(), /*access_mask=*/2), {}};
+    const Buffer &dst_buf = dst.GetBuffer();
     if (!IsBF16(dst.GetBuffer())) {
-      return prepared;
+      return {CreateRegion(dst_buf, dst.GetRanges(), /*access_mask=*/2),
+              {},
+              Buffer(),
+              false};
     }
-
+    // Reuse temp_fp32 if already exists (in-place update)
+    auto it = bf16_to_fp32_alias_.find(dst_buf);
+    if (it != bf16_to_fp32_alias_.end()) {
+      // No need to create a new temp, and no cast-back needed
+      return {CreateRegion(it->second, dst.GetRanges(), /*access_mask=*/2),
+              {},
+              it->second,
+              true};
+    }
+    // Otherwise, allocate a new temp FP32 buffer for the destination, and cast
+    // back after the op
     Buffer temp = CreateTempBuffer(dst.GetRanges(), DataType::Float(32),
                                    dst.GetBuffer().scope(), "bf16_dst_f32");
-    PrimExpr temp_src_region =
-        CreateRegion(temp, dst.GetRanges(), /*access_mask=*/1);
-    prepared.prefix.push_back(CreateCastStmt(temp_src_region, prepared.region));
-    prepared.region = CreateRegion(temp, dst.GetRanges(), /*access_mask=*/2);
-    return prepared;
+    bf16_to_fp32_alias_[dst_buf] = temp;
+    return {
+        CreateRegion(temp, dst.GetRanges(), /*access_mask=*/2), {}, temp, true};
   }
 
   Stmt VisitStmt_(const BlockNode *op) final {
@@ -180,7 +211,7 @@ private:
     if (new_allocs.same_as(new_block->alloc_buffers)) {
       return new_block;
     }
-
+    bf16_to_fp32_alias_.clear();
     new_block.CopyOnWrite()->alloc_buffers = std::move(new_allocs);
     return new_block;
   }
@@ -190,37 +221,67 @@ private:
     const auto *src0_call = call->args[0].as<CallNode>();
     const auto *src1_call = call->args[1].as<CallNode>();
     const auto *dst_call = call->args[2].as<CallNode>();
-    if (src0_call == nullptr || src1_call == nullptr || dst_call == nullptr ||
+    // Consider the vector-scalar case
+    if (src0_call == nullptr || dst_call == nullptr ||
         !src0_call->op.same_as(Op::Get("tl.region")) ||
-        !src1_call->op.same_as(Op::Get("tl.region")) ||
         !dst_call->op.same_as(Op::Get("tl.region"))) {
       return Evaluate(new_value);
     }
 
     RegionOp src0_region(src0_call->args, BufferMap{});
-    RegionOp src1_region(src1_call->args, BufferMap{});
+    bool src1_not_bf16 =
+        (src1_call == nullptr) || !src1_call->op.same_as(Op::Get("tl.region"));
+    if (!src1_not_bf16) {
+      RegionOp src1_region(src1_call->args, BufferMap{});
+      src1_not_bf16 = !IsBF16(src1_region.GetBuffer());
+    }
     RegionOp dst_region(dst_call->args, BufferMap{});
-    if (!IsBF16(src0_region.GetBuffer()) && !IsBF16(src1_region.GetBuffer()) &&
+    if (!IsBF16(src0_region.GetBuffer()) && src1_not_bf16 &&
         !IsBF16(dst_region.GetBuffer())) {
       return Evaluate(new_value);
     }
 
     String compute_scope = dst_region.GetBuffer().scope();
     PreparedRegion src0 = PrepareSourceRegion(src0_region, compute_scope);
-    PreparedRegion src1 = PrepareSourceRegion(src1_region, compute_scope);
+
     PreparedRegion dst = PrepareDestinationRegion(dst_region);
 
     Array<Stmt> seq;
     for (const Stmt &stmt : src0.prefix) {
       seq.push_back(stmt);
     }
-    for (const Stmt &stmt : src1.prefix) {
-      seq.push_back(stmt);
+
+    PrimExpr src1_expr = call->args[1];
+    // no need to process src1 if it's scalar or not bf16
+    if (!src1_not_bf16) {
+      RegionOp src1_region(src1_call->args, BufferMap{});
+      PreparedRegion src1 = PrepareSourceRegion(src1_region, compute_scope);
+      for (const Stmt &stmt : src1.prefix) {
+        seq.push_back(stmt);
+      }
+      src1_expr = src1.region;
     }
-    Array<PrimExpr> op_args{src0.region, src1.region, dst.region};
+
+    Array<PrimExpr> op_args{src0.region, src1_expr, dst.region};
+    if (call->args.size() > 3) {
+      // Pass through additional arguments (e.g., for cmp)
+      for (size_t i = 3; i < call->args.size(); ++i) {
+        op_args.push_back(call->args[i]);
+      }
+    }
     seq.push_back(Evaluate(Call(DataType::Void(), call->op, op_args)));
     for (const Stmt &stmt : dst.prefix) {
       seq.push_back(stmt);
+    }
+
+    // Insert cast-back for the destination if needed
+    if (dst.needs_cast_back) {
+      PrimExpr temp_src_region =
+          CreateRegion(dst.temp_fp32, dst_region.GetRanges(),
+                       /*access_mask=*/1);
+      PrimExpr real_dst_region = CreateRegion(
+          dst_region.GetBuffer(), dst_region.GetRanges(), /*access_mask=*/2);
+      seq.push_back(CreateCastStmt(temp_src_region, real_dst_region));
     }
     return SeqStmt::Flatten(seq);
   }
@@ -249,10 +310,27 @@ private:
     for (const Stmt &stmt : src.prefix) {
       seq.push_back(stmt);
     }
+
     Array<PrimExpr> op_args{src.region, dst.region};
+    if (call->args.size() > 2) {
+      // Pass through additional arguments (e.g., for reduce)
+      for (size_t i = 2; i < call->args.size(); ++i) {
+        op_args.push_back(call->args[i]);
+      }
+    }
     seq.push_back(Evaluate(Call(DataType::Void(), call->op, op_args)));
     for (const Stmt &stmt : dst.prefix) {
       seq.push_back(stmt);
+    }
+
+    // Insert cast-back for the destination if needed
+    if (dst.needs_cast_back) {
+      PrimExpr temp_src_region =
+          CreateRegion(dst.temp_fp32, dst_region.GetRanges(),
+                       /*access_mask=*/1);
+      PrimExpr real_dst_region = CreateRegion(
+          dst_region.GetBuffer(), dst_region.GetRanges(), /*access_mask=*/2);
+      seq.push_back(CreateCastStmt(temp_src_region, real_dst_region));
     }
     return SeqStmt::Flatten(seq);
   }
@@ -275,8 +353,6 @@ private:
   }
 
   int temp_buffer_id_{0};
-  std::vector<std::vector<Buffer>> block_temp_buffers_;
-  std::vector<std::vector<CachedSourceCast>> block_source_cast_cache_;
 };
 
 namespace transform {

--- a/testing/npuir/bf16_support_ops/test_gemm_bf16.py
+++ b/testing/npuir/bf16_support_ops/test_gemm_bf16.py
@@ -1,0 +1,61 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import torch
+import tilelang
+import tilelang.language as T
+import pytest
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("gemm_bf16"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["bfloat16"]
+
+
+@tilelang.jit(target="npuir")
+def gemm_bf16_func(
+    M, K, N, block_M, block_K, block_N, dtype="bfloat16", accum_dtype="float32"
+):
+    bx = T.ceildiv(N, block_N)
+    by = T.ceildiv(M, block_M)
+    bk = T.ceildiv(K, block_K)
+
+    @T.prim_func
+    def gemm_bf16_kernel(
+        A: T.Tensor((M, K), dtype),  # type: ignore
+        B: T.Tensor((K, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(bx * by, is_npu=True) as (cid, _):
+            local_a = T.alloc_shared((block_M, block_K), dtype)
+            local_b = T.alloc_shared((block_K, block_N), dtype)
+            local_c = T.alloc_shared((block_M, block_N), accum_dtype)
+            T.clear(local_c)
+            idx = cid % bx * block_N
+            idy = cid // bx * block_M
+            for k in T.Pipelined(bk):
+                idk = k * block_K
+                # Load A and B into shared memory
+                T.copy(A[idy : idy + block_M, idk : idk + block_K], local_a)
+                T.copy(B[idk : idk + block_K, idx : idx + block_N], local_b)
+                # Compute local_c += local_a @ local_b
+                T.gemm(local_a, local_b, local_c)
+
+            # Write back the result to C
+            T.copy(local_c, C[idy : idy + block_M, idx : idx + block_N])
+
+    return gemm_bf16_kernel
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_gemm_bf16(dtype):
+    M, K, N = 64, 128, 64
+    block_M, block_K, block_N = 16, 32, 16
+    A = gen_tensor((M, K), dtype)
+    B = gen_tensor((K, N), dtype)
+    C = gen_tensor((M, N), "float32", kind="zeros")
+    gemm_bf16_func(M, K, N, block_M, block_K, block_N)(A, B, C)
+    expected = (A @ B).to(torch.float32)
+    assert_close(C, expected, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/bf16_support_ops/test_mix_kernel_bf16.py
+++ b/testing/npuir/bf16_support_ops/test_mix_kernel_bf16.py
@@ -1,0 +1,70 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import torch
+import tilelang
+import tilelang.language as T
+import pytest
+
+from testcommon import assert_close, gen_tensor
+
+# this kernel has three input A, B, C, and 1 out,
+# first do tmp = A + B, then do out = tmp @ C
+
+pytestmark = [
+    pytest.mark.op("mix_kernel_bf16"),
+    pytest.mark.mode("Developer"),
+]
+DTYPES = ["bfloat16"]
+
+
+@tilelang.jit(target="npuir")
+def mix_kernel_bf16_func(
+    M, K, N, block_M, block_K, block_N, dtype="bfloat16", accum_dtype="float32"
+):
+    bx = T.ceildiv(N, block_N)
+    by = T.ceildiv(M, block_M)
+    bk = T.ceildiv(K, block_K)
+
+    @T.prim_func
+    def mix_kernel_bf16_kernel(
+        A: T.Tensor((M, K), dtype),  # type: ignore
+        B: T.Tensor((M, K), dtype),  # type: ignore
+        C: T.Tensor((K, N), dtype),  # type: ignore
+        out: T.Tensor((M, N), accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(bx * by, is_npu=True) as (cid, _):
+            local_a = T.alloc_shared((block_M, block_K), dtype)
+            local_b = T.alloc_shared((block_M, block_K), dtype)
+            local_c = T.alloc_shared((block_K, block_N), dtype)
+            local_out = T.alloc_shared((block_M, block_N), accum_dtype)
+            T.clear(local_out)
+            idx = cid % bx * block_N
+            idy = cid // bx * block_M
+            for k in T.Pipelined(bk):
+                idk = k * block_K
+                # Load A, B and C into shared memory
+                T.copy(A[idy : idy + block_M, idk : idk + block_K], local_a)
+                T.copy(B[idy : idy + block_M, idk : idk + block_K], local_b)
+                T.copy(C[idk : idk + block_K, idx : idx + block_N], local_c)
+                # Compute local_out += (local_a + local_b) @ local_c
+                local_tmp = T.alloc_shared((block_M, block_K), dtype)
+                T.vadd(local_a, local_b, local_tmp)
+                T.gemm(local_tmp, local_c, local_out)
+
+            # Write back the result to out
+            T.copy(local_out, out[idy : idy + block_M, idx : idx + block_N])
+
+    return mix_kernel_bf16_kernel
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_mix_kernel_bf16(dtype):
+    M, K, N = 64, 128, 64
+    block_M, block_K, block_N = 16, 32, 16
+    A = gen_tensor((M, K), dtype)
+    B = gen_tensor((M, K), dtype)
+    C = gen_tensor((K, N), dtype)
+    out = gen_tensor((M, N), "float32", kind="zeros")
+
+    mix_kernel_bf16_func(M, K, N, block_M, block_K, block_N)(A, B, C, out)
+    expected = ((A + B) @ C).to(torch.float32)
+    assert_close(out, expected, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/bf16_support_ops/test_reduce_add_bf16.py
+++ b/testing/npuir/bf16_support_ops/test_reduce_add_bf16.py
@@ -1,0 +1,44 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import tilelang
+import tilelang.language as T
+import pytest
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("reduce_add_bf16"),
+    pytest.mark.mode("Developer"),
+]
+DTYPES = ["bfloat16"]
+
+
+@tilelang.jit(target="npuir")
+def reduce_add_bf16_func(M, block_M, N, dtype="bfloat16", accum_dtype="float32"):
+    by = T.ceildiv(M, block_M)
+
+    @T.prim_func
+    def reduce_add_bf16_kernel(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        out: T.Tensor((block_M, 1), accum_dtype),  # type: ignore
+    ):
+        with T.Kernel(by, is_npu=True) as (cid, _):
+            idy = cid * block_M
+            local_a = T.alloc_shared((block_M, N), dtype)
+            local_out = T.alloc_shared((block_M, 1), accum_dtype)
+            T.clear(local_out)
+            T.copy(A[idy : idy + block_M, :], local_a)
+            T.reduce_sum(local_a, local_out, dim=1)
+            T.copy(local_out, out[idy : idy + block_M, 0])
+
+    return reduce_add_bf16_kernel
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_reduce_add_bf16(dtype):
+    M, N = 64, 64
+    block_M = 16
+    A = gen_tensor((M, N), dtype)
+    out = gen_tensor((M, 1), "float32", kind="zeros")
+    reduce_add_bf16_func(M, block_M, N)(A, out)
+    expected = A.float().sum(dim=1, keepdim=True)
+    assert_close(out, expected, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/bf16_support_ops/test_vselect_bf16.py
+++ b/testing/npuir/bf16_support_ops/test_vselect_bf16.py
@@ -1,0 +1,55 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import torch
+import tilelang
+import tilelang.language as T
+import pytest
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("vselect_bf16"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["bfloat16"]
+
+
+@tilelang.jit(target="npuir")
+def vselect_bf16_func(M, N, block_M, block_N, dtype="bfloat16"):
+    bx = T.ceildiv(N, block_N)
+    by = T.ceildiv(M, block_M)
+
+    @T.prim_func
+    def vselect_bf16_kernel(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        out: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(bx * by, is_npu=True) as (cid, _):
+            idx = cid % bx * block_N
+            idy = cid // bx * block_M
+            local_a = T.alloc_shared((block_M, block_N), dtype)
+            T.copy(A[idy : idy + block_M, idx : idx + block_N], local_a)
+            bool_mask = T.alloc_shared((block_M, block_N), "bool")
+
+            value = 0.5
+            T.vcmp(local_a, value, bool_mask, "gt")
+            local_out = T.alloc_shared((block_M, block_N), dtype)
+            local_tmp = T.alloc_shared((block_M, block_N), dtype)
+            T.clear(local_tmp)
+            T.vselect(bool_mask, local_a, local_tmp, local_out)
+            T.copy(local_out, out[idy : idy + block_M, idx : idx + block_N])
+
+    return vselect_bf16_kernel
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_vselect_bf16(dtype):
+    M, N = 64, 64
+    block_M, block_N = 16, 16
+    A = gen_tensor((M, N), dtype)
+    out = gen_tensor((M, N), dtype, kind="zeros")
+    vselect_bf16_func(M, N, block_M, block_N)(A, out)
+    expected = torch.where(A > 0.5, A, torch.zeros_like(A))
+    out = out.to(torch.float32)
+    expected = expected.to(torch.float32)
+    assert_close(out, expected, rtol=1e-2, atol=1e-2)

--- a/testing/npuir/bf16_support_ops/test_vv_bf16.py
+++ b/testing/npuir/bf16_support_ops/test_vv_bf16.py
@@ -1,0 +1,61 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026.
+import torch
+import tilelang
+import tilelang.language as T
+import pytest
+
+from testcommon import assert_close, gen_tensor
+
+# this kernel has three input A, B, C, and 1 out,
+# calculate out = A * B + C
+
+pytestmark = [
+    pytest.mark.op("vv_bf16"),
+    pytest.mark.mode("Developer"),
+]
+DTYPES = ["bfloat16"]
+
+
+@tilelang.jit(target="npuir")
+def vv_bf16_func(M, N, block_M, block_N, dtype="bfloat16"):
+    bx = T.ceildiv(N, block_N)
+    by = T.ceildiv(M, block_M)
+
+    @T.prim_func
+    def vv_bf16_kernel(
+        A: T.Tensor((M, N), dtype),  # type: ignore
+        B: T.Tensor((M, N), dtype),  # type: ignore
+        C: T.Tensor((M, N), dtype),  # type: ignore
+        out: T.Tensor((M, N), dtype),  # type: ignore
+    ):
+        with T.Kernel(bx * by, is_npu=True) as (cid, _):
+            local_a = T.alloc_shared((block_M, block_N), dtype)
+            local_b = T.alloc_shared((block_M, block_N), dtype)
+            local_c = T.alloc_shared((block_M, block_N), dtype)
+            local_out = T.alloc_shared((block_M, block_N), dtype)
+            idx = cid % bx * block_N
+            idy = cid // bx * block_M
+            T.copy(A[idy : idy + block_M, idx : idx + block_N], local_a)
+            T.copy(B[idy : idy + block_M, idx : idx + block_N], local_b)
+            local_tmp = T.alloc_shared((block_M, block_N), dtype)
+            T.vmul(local_a, local_b, local_tmp)
+            T.copy(C[idy : idy + block_M, idx : idx + block_N], local_c)
+            T.vadd(local_tmp, local_c, local_out)
+            T.copy(local_out, out[idy : idy + block_M, idx : idx + block_N])
+
+    return vv_bf16_kernel
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_vv_bf16(dtype):
+    M, N = 64, 64
+    block_M, block_N = 16, 16
+    A = gen_tensor((M, N), dtype)
+    B = gen_tensor((M, N), dtype)
+    C = gen_tensor((M, N), dtype)
+    out = gen_tensor((M, N), dtype, kind="zeros")
+    vv_bf16_func(M, N, block_M, block_N)(A, B, C, out)
+    expected = A * B + C
+    out = out.to(torch.float32)
+    expected = expected.to(torch.float32)
+    assert_close(out, expected, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
- remove redundant cast and fp32_temp buffer for multi arith op senario
- support vector-scalar cases
- support more binary and unary op