### PR TITLE
support bfloat16 dtype in out_idx

### DIFF
--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -1288,6 +1288,8 @@ class compiler_npu:
         mapping = {
             "float16": torch.float16,
             "float32": torch.float32,
+            "float64": torch.float64,
+            "bfloat16": torch.bfloat16,
             "int8": torch.int8,
             "int16": torch.int16,
             "int32": torch.int32,


### PR DESCRIPTION
support bfloat16 in out_idx:
modify the func  _tvm_dtype_to_torch