### PR TITLE
[Example] Fix act_quant kernel: round_mode and scale shape

### DIFF
--- a/examples/deepseek_v4/example_act_quant_kernel.py
+++ b/examples/deepseek_v4/example_act_quant_kernel.py
@@ -64,7 +64,7 @@ def act_quant_kernel(
                 x_ub_fp[i, j] = x_ub_fp[i, j] / scale_ub[i, 0]
 
             T.vclamp(x_ub_fp, x_ub_fp, -127.0, 127.0)
-            T.vcast(x_ub_fp, x_ub_fp, round_mode="round")
+            T.vcast(x_ub_fp, x_ub_fp, round_mode="rint")  # match torch.round semantics (tie-to-even / IEEE banker rounding)
 
             T.vcast(x_ub_fp, x_ub_half)
             T.vcast(x_ub_half, y_ub)
@@ -93,7 +93,7 @@ def act_quant(
     N = x.size(-1)
     y = torch.empty_like(x, dtype=torch.int8)
     #s = x.new_empty(*x.size()[:-1], N, dtype=torch.float32)
-    s = x.new_empty(N, 1, dtype=torch.float32)
+    s = x.new_empty(x.size(0), 1, dtype=torch.float32)  # rows (M), not cols (N) — latent bug at M==N
     kernel = act_quant_kernel(N, round_scale=scale_fmt is not None)
     kernel(x.view(-1, N), y.view(-1, N), s.view(-1, N))
     return y, s


### PR DESCRIPTION
## Summary

Two latent bugs in `examples/deepseek_v4/example_act_quant_kernel.py`:

1. **Round mode mismatch**: `T.vcast(..., round_mode=\"round\")` uses tie-away-from-zero (C `round()`). `torch.round()` uses tie-to-even (IEEE banker). At exactly 0.5 values, NPU and torch produce different int8 outputs, failing the strict `assert torch.all(y == y_ref)` check.
   **Fix**: `round_mode='rint'`.

2. **Scale shape typo**: Host-side `s = x.new_empty(N, 1, ...)` uses N (cols) instead of M (rows). Scale should be per-row `[M, 1]` to match the torch reference. Bug was latent when M==N (default 64x64 case); surfaces at M=64 N=32 as `shape mismatch torch.Size([32, 1]) != torch.Size([64, 1])`.
   **Fix**: `s = x.new_empty(x.size(0), 1, ...)`.

## Test plan

- [x] `python3 examples/deepseek_v4/example_act_quant_kernel.py` with M=64 N=32 bfloat16 → "Comparison passed."
- [x] Both fixes are 1-line each; no regression risk on other examples.