### PR TITLE
[Tests] Fix args order in unittest/npuir atomic_add tests

### DIFF
--- a/unittest/npuir/test_atomic_add_1d_dev.py
+++ b/unittest/npuir/test_atomic_add_1d_dev.py
@@ -29,7 +29,7 @@ def vec_atomic_add_1d(N, block_size, dtype="float32"):
             tail_size = T.min(block_size, t0)
             T.copy(A[start : start + tail_size], A_VEC[0:tail_size])
     
-            T.npuir_atomic_add(A_VEC, B[start], [tail_size])
+            T.npuir_atomic_add(B[start], A_VEC, [tail_size])  # args match wrapper signature: npuir_atomic_add(dst, src, size)
 
     return vecAtomicAdd1D
 

--- a/unittest/npuir/test_atomic_add_1d_exp.py
+++ b/unittest/npuir/test_atomic_add_1d_exp.py
@@ -32,7 +32,7 @@ def vec_atomic_add_1d(N, block_size, dtype="float32"):
             
             T.copy(A[start : start + tail_size], A_VEC[0:tail_size])
 
-            T.npuir_atomic_add(A_VEC, B[start], [tail_size])
+            T.npuir_atomic_add(B[start], A_VEC, [tail_size])  # args match wrapper signature: npuir_atomic_add(dst, src, size)
             
             # T.copy(A_VEC[0:tail_size], B[start : start + tail_size])
 

--- a/unittest/npuir/test_atomic_add_2d_dev.py
+++ b/unittest/npuir/test_atomic_add_2d_dev.py
@@ -35,7 +35,7 @@ def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
             t0 = shape_N - by
             tile_size_N = T.min(block_N, t0)   
             T.copy(A[bx : bx + tile_size_M, by : by + tile_size_N], A_VEC[0:tile_size_M, 0:tile_size_N]) 
-            T.npuir_atomic_add(A_VEC, B[bx, by], [tile_size_M, tile_size_N])           
+            T.npuir_atomic_add(B[bx, by], A_VEC, [tile_size_M, tile_size_N])  # args match wrapper signature: npuir_atomic_add(dst, src, size)           
 
 
     return vecAtomicAdd2D

--- a/unittest/npuir/test_atomic_add_2d_exp.py
+++ b/unittest/npuir/test_atomic_add_2d_exp.py
@@ -35,7 +35,7 @@ def vec_atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
             t0 = shape_N - by
             tile_size_N = T.min(block_N, t0)   
             T.copy(A[bx : bx + tile_size_M, by : by + tile_size_N], A_VEC[0:tile_size_M, 0:tile_size_N]) 
-            T.npuir_atomic_add(A_VEC, B[bx, by], [tile_size_M, tile_size_N])           
+            T.npuir_atomic_add(B[bx, by], A_VEC, [tile_size_M, tile_size_N])  # args match wrapper signature: npuir_atomic_add(dst, src, size)           
             
     return vecAtomicAdd2D
 

--- a/unittest/npuir/test_atomic_addx4_dev.py
+++ b/unittest/npuir/test_atomic_addx4_dev.py
@@ -37,7 +37,7 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
                 t0 = shape_N - by
                 tile_size_N = T.min(block_N, t0)   
                 T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
-                T.npuir_atomic_addx4(A_VEC, B[bx, by], [1, 4])            
+                T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])  # args match wrapper signature: npuir_atomic_add(dst, src, size)            
             
     return atomicAddx4Program
 

--- a/unittest/npuir/test_atomic_addx4_exp.py
+++ b/unittest/npuir/test_atomic_addx4_exp.py
@@ -37,7 +37,7 @@ def run_atomic_addx4(M, N, block_M, block_N, dtype="float32"):
                 t0 = shape_N - by
                 tile_size_N = T.min(block_N, t0)   
                 T.copy(A[bx : bx + 1, by : by + 4], A_VEC[0:1, 0:4])
-                T.npuir_atomic_addx4(A_VEC, B[bx, by], [1, 4])            
+                T.npuir_atomic_addx4(B[bx, by], A_VEC, [1, 4])  # args match wrapper signature: npuir_atomic_add(dst, src, size)            
             
     return atomicAddx4Program
 


### PR DESCRIPTION
## Summary

6 tests in \`unittest/npuir/\` call \`T.npuir_atomic_add(UB_src, GM_dst, size)\`. The wrapper signature in \`tilelang/language/customize_npuir.py\` is:

\`\`\`python
def npuir_atomic_add(dst, src, size: Optional[list] = None):
\`\`\`

— dst first, src second. The mismatched args caused the codegen to emit \`hivm.hir.store(src=GM, dst=UB)\` which the bishengir verifier rejects with **'only support store ub to gm currently!'**.

The reference IRs in \`unittest/npuir/mlir_files/atomic_add_*.mlir\` show the correct semantic (\`ins=tensor[UB], outs=memref[GM]\`), confirming the tests had the typo, not the codegen.

## Files changed

- \`unittest/npuir/test_atomic_add_1d_dev.py\`
- \`unittest/npuir/test_atomic_add_1d_exp.py\`
- \`unittest/npuir/test_atomic_add_2d_dev.py\`
- \`unittest/npuir/test_atomic_add_2d_exp.py\`
- \`unittest/npuir/test_atomic_addx4_dev.py\`
- \`unittest/npuir/test_atomic_addx4_exp.py\`

## Test plan

- [x] All 6 tests now run \`tilelang.engine.lower()\` cleanly (no verifier error)
- [x] They still report \`'are not identical'\` against \`mlir_files/*.mlir\` due to **unrelated** constant-folding differences in current compiler output (a separate snapshot-staleness issue that affects most \`unittest/npuir/\` tests). This PR only addresses the args order; snapshot refresh is a separate concern.