### PR TITLE
[AscendNPU-IR][A5] Fix silent cache bug: negative out_idx + dynamic shape + disk-cache hit returns int instead of output tensor

### DIFF
--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -152,7 +152,18 @@ class KernelCache:
         JitKernel_NPU
             A compiled, ready-to-run NPU kernel wrapper.
         """
-        from tilelang.jit.jit_npu import compiler_npu
+        from tilelang.jit.jit_npu import compiler_npu, _normalize_out_idx
+
+        # Normalize ``out_idx`` once at the cache boundary so that the cache
+        # key, the compile path, and the pickled metadata all agree on a
+        # single canonical (non-negative, list) form.  Without this,
+        # ``out_idx=-1`` and ``out_idx=[N-1]`` would occupy separate cache
+        # entries, and a cache hit could deserialize a metadata ``out_idx``
+        # whose form differs from the lookup value -- which was the source
+        # of a silent bug where ``full_args[-1]`` pointed at an appended
+        # symbolic value instead of the output tensor.
+        if out_idx is not None:
+            out_idx = _normalize_out_idx(out_idx, len(func.params))
 
         _key = self._generate_compile_key(
             func=func,
@@ -437,6 +448,7 @@ class KernelCache:
             kernel_launcher_path=str(cache_path / AUTOTUNE_SO_LAUNCHER_PATH),
             kernel_utils_path=None,
             metadata=metadata,
+            out_idx=out_idx,
         )
 
     def _try_save(self, label: str, fn: Callable) -> None:

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -437,7 +437,6 @@ class KernelCache:
             kernel_launcher_path=str(cache_path / AUTOTUNE_SO_LAUNCHER_PATH),
             kernel_utils_path=None,
             metadata=metadata,
-            out_idx=out_idx,
         )
 
     def _try_save(self, label: str, fn: Callable) -> None:

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -821,12 +821,9 @@ class JitKernel_NPU:
         kernel_launcher_path: str,
         kernel_utils_path: str,
         metadata: str,
-        out_idx: Union[List[int], int],
     ):
-        if isinstance(out_idx, int):
-            out_idx = [out_idx]
+
         metadata["so_launcher_path"] = kernel_launcher_path
-        metadata["out_idx"] = out_idx
         instance = cls(metadata)
         instance.so_launcher_path = kernel_launcher_path
         instance.so_utils_path = kernel_utils_path

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -47,7 +47,15 @@ def _normalize_out_idx(out_idx, total_params):
         raise TypeError(
             f"out_idx must be int, list, or tuple; got {type(out_idx).__name__}"
         )
-    return [i if i >= 0 else total_params + i for i in out_idx]
+    normalized = []
+    for i in out_idx:
+        idx = i if i >= 0 else total_params + i
+        if idx < 0 or idx >= total_params:
+            raise ValueError(
+                f"out_idx {i} is out of bounds for kernel with {total_params} parameters"
+            )
+        normalized.append(idx)
+    return normalized
 
 
 class LaunchThreadExtractor:

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -841,7 +841,10 @@ class JitKernel_NPU:
         # fall back to the value pickled in ``metadata`` (which is already
         # in canonical, non-negative form because the cache layer
         # normalised it before storing).
-        self.out_idx = out_idx if out_idx is not None else metadata["out_idx"]
+        self.out_idx = _normalize_out_idx(
+            out_idx if out_idx is not None else metadata["out_idx"],
+            len(self.params)
+        )
         self._launch()
 
     @classmethod

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -27,6 +27,29 @@ from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.transform.pass_config import normalize_pass_configs
 
 
+def _normalize_out_idx(out_idx, total_params):
+    """Normalize ``out_idx`` to a list of non-negative indices.
+
+    Accepts ``None``, a single ``int``, or a ``list``/``tuple`` of ``int``.
+    Negative indices are converted to their positive equivalents using
+    ``total_params``.  This is the single source of truth for the canonical
+    form of ``out_idx`` and is applied consistently across the cache key,
+    the compile path, and the pickled metadata so that e.g. ``[-1]`` and
+    ``[N-1]`` cannot diverge between code paths.
+    """
+    if out_idx is None:
+        return None
+    if isinstance(out_idx, int):
+        out_idx = [out_idx]
+    elif isinstance(out_idx, (list, tuple)):
+        out_idx = list(out_idx)
+    else:
+        raise TypeError(
+            f"out_idx must be int, list, or tuple; got {type(out_idx).__name__}"
+        )
+    return [i if i >= 0 else total_params + i for i in out_idx]
+
+
 class LaunchThreadExtractor:
     def __init__(self) -> None:
         self.expressions = []
@@ -779,7 +802,11 @@ class JitKernel_NPU:
     def __init__(self, metadata: dict, out_idx=None) -> None:
         self.params = metadata["params"]
         self.signature = metadata.get("signature", {})
-        self.out_idx = out_idx
+        # NOTE: ``self.out_idx`` is set at the end of __init__ from either
+        # the explicit ``out_idx`` argument or from ``metadata["out_idx"]``
+        # (whichever is available).  Do not set it here -- doing so used to
+        # be silently overwritten and made the constructor parameter look
+        # functional when it wasn't.
         self.param_info = metadata.get("param_info", [])
         # 1 launch path
         self.so_launcher_path = metadata.get(
@@ -810,7 +837,11 @@ class JitKernel_NPU:
         self.gridfunc = metadata["gridfunc"]
         self.symbolic = metadata["symbolic"]
         self.prim_func = metadata["primfunc"]
-        self.out_idx = metadata["out_idx"]
+        # Respect explicit ``out_idx`` if the caller provided one; otherwise
+        # fall back to the value pickled in ``metadata`` (which is already
+        # in canonical, non-negative form because the cache layer
+        # normalised it before storing).
+        self.out_idx = out_idx if out_idx is not None else metadata["out_idx"]
         self._launch()
 
     @classmethod
@@ -821,8 +852,17 @@ class JitKernel_NPU:
         kernel_launcher_path: str,
         kernel_utils_path: str,
         metadata: str,
+        out_idx: Union[List[int], int],
     ):
-
+        # ``metadata["out_idx"]`` was stored at compile time and is already
+        # in canonical (non-negative, list) form -- the cache layer
+        # normalised it before hashing the key.  Do NOT let an
+        # unnormalised caller-supplied value overwrite it: that was the
+        # source of a silent bug where ``out_idx=[-1]`` plus dynamic
+        # symbolic shapes plus a disk-cache hit caused ``full_args[-1]``
+        # to index into appended symbolic values instead of the output
+        # tensor (and a kernel call returned an ``int`` instead of a
+        # ``torch.Tensor``).
         metadata["so_launcher_path"] = kernel_launcher_path
         instance = cls(metadata)
         instance.so_launcher_path = kernel_launcher_path
@@ -1117,10 +1157,9 @@ class compiler_npu:
         self.original_mod = mod
         # extract_param_info
         param_info = self._extract_param_info(mod, out_idx)
-        # process negative out_idx
-        if out_idx is not None:
-            total_params = len(param_info)
-            out_idx = [i if i >= 0 else total_params + i for i in out_idx]
+        # Normalise out_idx to canonical (non-negative, list) form.
+        # Idempotent: if the cache layer already did this, this is a no-op.
+        out_idx = _normalize_out_idx(out_idx, len(param_info))
         self.metadata = {}
         self.metadata["out_idx"] = out_idx
         self.metadata["param_info"] = param_info
@@ -1385,7 +1424,7 @@ class compiler_npu:
         arch = NPUUtils().get_arch()
         is_910_95 = "910_95" in arch or "950" in arch
         compiler_inserted_params = 2 if is_910_95 else 3
-        
+
         for param in params[compiler_inserted_params: -6]:
             # Check if the type includes the target type
             found_type = None


### PR DESCRIPTION
### Root Cause

`out_idx` was normalised on the compile path (`[-1]` → `[2]` and pickled to `metadata.pkl`) but `JitKernel_NPU.from_database()` overwrote the pickled value with the unnormalised caller input. On the cache-hit path, `__call__` then computed `full_args[-1]`, which — after `full_args.extend(extra_args)` from dynamic shapes — pointed at an appended symbolic dim value instead of the output tensor.

Two latent issues made this possible:

- `JitKernel_NPU.__init__` accepted `out_idx` but silently overwrote it with `metadata["out_idx"]`, so the parameter was inert.
- Cache key was hashed from unnormalised `out_idx`, so `[-1]` and `[N-1]` produced different keys for the same kernel.

### Fix

Single normalisation helper, applied consistently at every boundary.

- **`tilelang/jit/jit_npu.py`**
  - Add `_normalize_out_idx(out_idx, total_params)` — idempotent, handles `None`/`int`/`list`/`tuple`.
  - `compiler_npu.compile()` uses the helper.
  - `JitKernel_NPU.from_database()` no longer overwrites `metadata["out_idx"]`.
  - `JitKernel_NPU.__init__()` final assignment now respects the constructor argument.
- **`tilelang/cache/kernel_cache.py`**
  - `cached_npu()` normalises `out_idx` once at the cache boundary so the cache key, compile path, and pickled metadata all agree.