### PR TITLE
[AscendNPU-IR] Fix silent cache bug: negative out_idx + dynamic shape + disk-cache hit returns int instead of output tensor

### DIFF
--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -152,7 +152,18 @@ class KernelCache:
         JitKernel_NPU
             A compiled, ready-to-run NPU kernel wrapper.
         """
-        from tilelang.jit.jit_npu import compiler_npu
+        from tilelang.jit.jit_npu import compiler_npu, _normalize_out_idx
+
+        # Normalize ``out_idx`` once at the cache boundary so that the cache
+        # key, the compile path, and the pickled metadata all agree on a
+        # single canonical (non-negative, list) form.  Without this,
+        # ``out_idx=-1`` and ``out_idx=[N-1]`` would occupy separate cache
+        # entries, and a cache hit could deserialize a metadata ``out_idx``
+        # whose form differs from the lookup value -- which was the source
+        # of a silent bug where ``full_args[-1]`` pointed at an appended
+        # symbolic value instead of the output tensor.
+        if out_idx is not None:
+            out_idx = _normalize_out_idx(out_idx, len(func.params))
 
         _key = self._generate_compile_key(
             func=func,

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -884,7 +884,8 @@ class JitKernel_NPU:
         # in canonical, non-negative form because the cache layer
         # normalised it before storing).
         self.out_idx = _normalize_out_idx(
-            out_idx if out_idx is not None else metadata["out_idx"], len(self.param_info)
+            out_idx if out_idx is not None else metadata["out_idx"],
+            len(self.param_info),
         )
         self._launch()
 

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -884,7 +884,7 @@ class JitKernel_NPU:
         # in canonical, non-negative form because the cache layer
         # normalised it before storing).
         self.out_idx = _normalize_out_idx(
-            out_idx if out_idx is not None else metadata["out_idx"], len(self.params)
+            out_idx if out_idx is not None else metadata["out_idx"], len(self.param_info)
         )
         self._launch()
 

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -27,6 +27,37 @@ from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.transform.pass_config import normalize_pass_configs
 
 
+def _normalize_out_idx(out_idx, total_params):
+    """Normalize ``out_idx`` to a list of non-negative indices.
+
+    Accepts ``None``, a single ``int``, or a ``list``/``tuple`` of ``int``.
+    Negative indices are converted to their positive equivalents using
+    ``total_params``.  This is the single source of truth for the canonical
+    form of ``out_idx`` and is applied consistently across the cache key,
+    the compile path, and the pickled metadata so that e.g. ``[-1]`` and
+    ``[N-1]`` cannot diverge between code paths.
+    """
+    if out_idx is None:
+        return None
+    if isinstance(out_idx, int):
+        out_idx = [out_idx]
+    elif isinstance(out_idx, (list, tuple)):
+        out_idx = list(out_idx)
+    else:
+        raise TypeError(
+            f"out_idx must be int, list, or tuple; got {type(out_idx).__name__}"
+        )
+    normalized = []
+    for i in out_idx:
+        idx = i if i >= 0 else total_params + i
+        if idx < 0 or idx >= total_params:
+            raise ValueError(
+                f"out_idx {i} is out of bounds for kernel with {total_params} parameters"
+            )
+        normalized.append(idx)
+    return normalized
+
+
 class LaunchThreadExtractor:
     def __init__(self) -> None:
         self.expressions = []
@@ -813,7 +844,11 @@ class JitKernel_NPU:
     def __init__(self, metadata: dict, out_idx=None) -> None:
         self.params = metadata["params"]
         self.signature = metadata.get("signature", {})
-        self.out_idx = out_idx
+        # NOTE: ``self.out_idx`` is set at the end of __init__ from either
+        # the explicit ``out_idx`` argument or from ``metadata["out_idx"]``
+        # (whichever is available).  Do not set it here -- doing so used to
+        # be silently overwritten and made the constructor parameter look
+        # functional when it wasn't.
         self.param_info = metadata.get("param_info", [])
         # 1 launch path
         self.so_launcher_path = metadata.get(
@@ -844,7 +879,13 @@ class JitKernel_NPU:
         self.gridfunc = metadata["gridfunc"]
         self.symbolic = metadata["symbolic"]
         self.prim_func = metadata["primfunc"]
-        self.out_idx = metadata["out_idx"]
+        # Respect explicit ``out_idx`` if the caller provided one; otherwise
+        # fall back to the value pickled in ``metadata`` (which is already
+        # in canonical, non-negative form because the cache layer
+        # normalised it before storing).
+        self.out_idx = _normalize_out_idx(
+            out_idx if out_idx is not None else metadata["out_idx"], len(self.params)
+        )
         self._launch()
 
     @classmethod
@@ -857,10 +898,16 @@ class JitKernel_NPU:
         metadata: str,
         out_idx: Union[List[int], int],
     ):
-        if isinstance(out_idx, int):
-            out_idx = [out_idx]
+        # ``metadata["out_idx"]`` was stored at compile time and is already
+        # in canonical (non-negative, list) form -- the cache layer
+        # normalised it before hashing the key.  Do NOT let an
+        # unnormalised caller-supplied value overwrite it: that was the
+        # source of a silent bug where ``out_idx=[-1]`` plus dynamic
+        # symbolic shapes plus a disk-cache hit caused ``full_args[-1]``
+        # to index into appended symbolic values instead of the output
+        # tensor (and a kernel call returned an ``int`` instead of a
+        # ``torch.Tensor``).
         metadata["so_launcher_path"] = kernel_launcher_path
-        metadata["out_idx"] = out_idx
         instance = cls(metadata)
         instance.so_launcher_path = kernel_launcher_path
         instance.so_utils_path = kernel_utils_path
@@ -1154,10 +1201,9 @@ class compiler_npu:
         self.original_mod = mod
         # extract_param_info
         param_info = self._extract_param_info(mod, out_idx)
-        # process negative out_idx
-        if out_idx is not None:
-            total_params = len(param_info)
-            out_idx = [i if i >= 0 else total_params + i for i in out_idx]
+        # Normalise out_idx to canonical (non-negative, list) form.
+        # Idempotent: if the cache layer already did this, this is a no-op.
+        out_idx = _normalize_out_idx(out_idx, len(param_info))
         self.metadata = {}
         self.metadata["out_idx"] = out_idx
         self.metadata["param_info"] = param_info

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -908,7 +908,7 @@ class JitKernel_NPU:
         # tensor (and a kernel call returned an ``int`` instead of a
         # ``torch.Tensor``).
         metadata["so_launcher_path"] = kernel_launcher_path
-        instance = cls(metadata)
+        instance = cls(metadata, out_idx=out_idx)
         instance.so_launcher_path = kernel_launcher_path
         instance.so_utils_path = kernel_utils_path
         return instance


### PR DESCRIPTION
same modification as
https://github.com/tile-ai/tilelang-mlir-ascend/commit/29f50c41fdecd7f07378bf39f3b38f5b679cb1a6