### PR TITLE
fix(sparse_mla_fwd): write only valid head rows when heads < block_H

### DIFF
--- a/examples/sparse_mla_fwd.py
+++ b/examples/sparse_mla_fwd.py
@@ -367,9 +367,12 @@ def sparse_attention_mla(
                                              size=[block_H_half, tail_size_k])
 
                                 offset = batch_id * heads_mul_seq_len + seq_id * heads + block_h_offset
-                                T.copy(
-                                    ub_cross_kernel_16[0:block_H_half, 0:tail_size_k],
-                                    Output[offset : offset + block_H_half, block_k_offset : block_k_offset + tail_size_k])
+                                # FIX(heads<block_H): write only valid head rows; block_h_offset may exceed heads
+                                _valid_h = T.max(0, T.min(block_H_half, heads - block_h_offset))
+                                if _valid_h > 0:
+                                    T.copy(
+                                        ub_cross_kernel_16[0:_valid_h, 0:tail_size_k],
+                                        Output[offset : offset + _valid_h, block_k_offset : block_k_offset + tail_size_k])
 
     return main
 


### PR DESCRIPTION
## Problem

`examples/sparse_mla_fwd.py` silently produces wrong output when the attention head count is below 16, with no error raised. It passes at `heads >= 16`.

```
python examples/sparse_mla_fwd.py --heads 4    # ~44.3% elements mismatch vs the PyTorch ref
python examples/sparse_mla_fwd.py --heads 8    # ~35.9% mismatch
python examples/sparse_mla_fwd.py --heads 16   # All check passed!
python examples/sparse_mla_fwd.py --heads 32   # All check passed! (default)
```

Verified on Ascend A3 (Ascend910_9382, CANN 8.5.2).

## Root cause

For `heads < 16`, `padded_H = max(next_power_of_2(head_kv), 16)` pads the head dim up to 16, so `block_H = 16`. In the final output store, `block_h_offset = block_h_id * block_H + subid * block_H_half` can reach or exceed `heads`, but the store wrote a full `block_H_half` rows regardless:

```python
offset = batch_id * heads_mul_seq_len + seq_id * heads + block_h_offset
T.copy(ub_cross_kernel_16[0:block_H_half, ...], Output[offset : offset + block_H_half, ...])
```

So the write-back over-ran into the next `(batch, seq)` position's output rows. The padding head rows themselves compute independently and harmlessly — the only corruption is this over-write.

## Fix

Bound the store to the valid head rows:

```python
offset = batch_id * heads_mul_seq_len + seq_id * heads + block_h_offset
_valid_h = T.max(0, T.min(block_H_half, heads - block_h_offset))
if _valid_h > 0:
    T.copy(ub_cross_kernel_16[0:_valid_h, ...], Output[offset : offset + _valid_h, ...])
```

## Verification

`--heads 4 / 8 / 16 / 32` all pass after the fix (4 and 8 previously failed); no regression at 16/32.
