### PR TITLE
[Example] Add run_all.py for multi-NPU parallel validation, reorganize examples and refactor CI

### DIFF
--- a/.github/workflows/base_ci.yml
+++ b/.github/workflows/base_ci.yml
@@ -51,10 +51,10 @@ jobs:
         python -m pre_commit run --files $(tr '\n' ' ' < /tmp/changed_files.txt)
 
   # ============================================================
-  # Doc link check (PR only, after format passes)
+  # Doc link check (PR only, runs regardless of format result)
   # ============================================================
   doc-link-check:
-    if: github.event_name == 'pull_request' && needs.format.result == 'success'
+    if: always() && github.event_name == 'pull_request'
     needs: format
     uses: ./.github/workflows/doc-link-check.yml
 

--- a/.github/workflows/test_npuir_wheel.yml
+++ b/.github/workflows/test_npuir_wheel.yml
@@ -75,67 +75,7 @@ jobs:
       run: |
         set -euo pipefail
         mkdir -p testing/npuir/output/examples
-
-        EXAMPLE_FILES=(
-          examples/deepseek_v32/sparse_mla_bwd.py
-          examples/deepseek_v32/sparse_mla_fwd.py
-          examples/elementwise/atomic_add_dev.py
-          examples/elementwise/atomic_add.py
-          examples/elementwise/example_elementwise_add.py
-          examples/elementwise/vec_add_1d.py
-          examples/elementwise/vec_add_2d_dynamic_shape.py
-          examples/elementwise/vec_add_2d.py
-          examples/elementwise/vec_add_auto_brc.py
-          examples/gemm/example_gemm.py
-          examples/gemm/example_gemm_int82int32.py
-          examples/gemm/matmul_dynamic_shape.py
-          examples/gemm/matmul.py
-          examples/gemv/example_gemv.py
-          examples/mixcv/example_mixcv.py
-          examples/norm/example_rms_norm.py
-          examples/exp2.py
-          examples/log2.py
-          examples/flash_attn_npuir.py
-          examples/mixcv_mixkernel.py
-          examples/flash_attn_npuir_dev.py
-          examples/sparse_mla_fwd.py
-          examples/vectorization_in_parallel.py
-          examples/engram/engram_bwd_exp.py
-          examples/engram/engram_bwd.py
-          examples/engram/engram_decode.py
-          examples/engram/engram_fwd.py
-          examples/sparse_mla_fwd_dynamic_shape.py
-          examples/deepseek_v4/engram/engram_gate_kernel_bwd.py
-          examples/deepseek_v4/engram/engram_gate_kernel_fwd.py
-          examples/deepseek_v4/example_act_quant_kernel.py
-          examples/deepseek_v4/example_hc_split_sinkhorn_kernel.py
-          examples/deepseek_v4/example_mhc_post.py
-          examples/deepseek_v4/example_sparse_attn_kernel_highperf.py
-          examples/deepseek_v4/example_sparse_attn_kernel.py
-          examples/deepseek_v4/example_sparse_attn_bwd_kernel.py
-          examples/deepseek_v4/example_sparse_mla_fwd_kernel.py
-          examples/deepseek_v4/example_lighting_indexer_fwd_kernel.py
-          examples/deepseek_v4/example_lighting_indexer_bwd_kernel.py
-          examples/norm/layer_norm.py
-          examples/norm/rms_norm.py
-          examples/norm/group_norm.py
-        )
-
-        for script in "${EXAMPLE_FILES[@]}"; do
-          if [[ ! -f "${script}" ]]; then
-            echo "::error::Example file not found: ${script}"
-            exit 1
-          fi
-
-          log_file="testing/npuir/output/examples/$(basename "${script}").log"
-          echo "Running: python ${script}"
-          python "${script}" 2>&1 | tee "${log_file}"
-
-          if ! grep -Eqi "passed|success" "${log_file}"; then
-            echo "::error::${script} did not print a success marker. Expected 'passed' or 'success' in output."
-            exit 1
-          fi
-        done
+        python examples/run_all.py --sequential 2>&1 | tee testing/npuir/output/examples/run_all.log
 
     - name: Run npuir tests
       env:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you need to access Ascend NPU computing resources for development or testing,
 **tile-lang** provides the building blocks to implement a wide variety of operators. Some examples include:
 
 - [Vector Add](./examples/elementwise/vec_add_1d.py)
-- [Flash Attention](./examples/flash_attn_npuir.py)
+- [Flash Attention](./examples/flash_attention/flash_attn_npuir.py)
 
 Within the `examples` directory, you will also find additional complex kernels—such as convolutions, forward/backward passes for FlashAttention, more operators will continuously be added.
 
@@ -283,8 +283,6 @@ def test_vec_add():
     Test function to validate the vector addition kernel.
     Compares the result of the custom TileLang kernel against PyTorch's native addition.
     """
-    # Set the target NPU device (device ID 6 in this case)
-    torch.npu.set_device(6)
 
     # Instantiate the vector addition kernel for the full sequence length (single block)
     func = vec_add(seq_len, seq_len)

--- a/examples/deepseek_v32/fp8_lighting_indexer.py
+++ b/examples/deepseek_v32/fp8_lighting_indexer.py
@@ -9,7 +9,6 @@ import torch.nn as nn
 import tilelang
 import tilelang.language as T
 
-torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
 

--- a/examples/deepseek_v32/sparse_mla_fwd_dynamic_shape.py
+++ b/examples/deepseek_v32/sparse_mla_fwd_dynamic_shape.py
@@ -649,9 +649,6 @@ def run_test(verify_acc=True):
 
 
 if __name__ == "__main__":
-    # Specifies which NPU device to use
-    torch.npu.set_device(0)
-
     # Generate data and run tests
     generate_data()
     run_test(verify_acc=True)

--- a/examples/deepseek_v32/sparse_mla_fwd_exp.py
+++ b/examples/deepseek_v32/sparse_mla_fwd_exp.py
@@ -6,8 +6,6 @@ import tilelang
 from tilelang import language as T
 from tilelang import tvm
 
-torch.npu.set_device(0)
-
 # Clear tilelang cache
 tilelang.cache.clear_cache()
 

--- a/examples/deepseek_v4/example_lighting_indexer_bwd_kernel.py
+++ b/examples/deepseek_v4/example_lighting_indexer_bwd_kernel.py
@@ -256,7 +256,6 @@ def lighting_indexer_bwd(
 
 
 def _smoke_bwd():
-    torch.npu.set_device(0)
     # T33: probe per-shape stability of the bwd kernel. Standalone PASS at
     # SEQ=1,K=8,BI=8 doesn't generalize: the shim hit garbage dk values at
     # K=4,BI=4. Test K=BI=4 here to see if same garbage repros.

--- a/examples/deepseek_v4/example_lighting_indexer_fwd_kernel.py
+++ b/examples/deepseek_v4/example_lighting_indexer_fwd_kernel.py
@@ -161,7 +161,6 @@ def _ref_indexer(q_flat, kv, weights):
 
 
 def test_lighting_indexer_fwd_small():
-    torch.npu.set_device(0)
     SEQ, SKV, H, D = 8, 16, 8, 32
     BN, BQ = 16, 4
 

--- a/examples/deepseek_v4/example_sparse_attn_kernel_highperf.py
+++ b/examples/deepseek_v4/example_sparse_attn_kernel_highperf.py
@@ -901,8 +901,4 @@ def run_test(verify_acc=True):
 
 
 if __name__ == "__main__":
-    # Specifies which NPU device to use
-    torch.npu.set_device(0)
-
-    # Run tests
     run_test(verify_acc=True)

--- a/examples/deepseek_v4/example_sparse_mla_fwd_kernel.py
+++ b/examples/deepseek_v4/example_sparse_mla_fwd_kernel.py
@@ -180,7 +180,6 @@ def _ref_torch(q, kv, indices, sm_scale=None):
 
 
 def test_sparse_mla_fwd_small():
-    torch.npu.set_device(0)
     B, S, SKV, H = 1, 8, 16, 16
     D, DT = 64, 16
     topk = 8

--- a/examples/elementwise/atomic_add.py
+++ b/examples/elementwise/atomic_add.py
@@ -67,7 +67,6 @@ def atomic_add_2d(M, N, block_M, block_N, dtype="float32"):
 #  Tests
 # ---------------------------------------------------------------------------
 def test_atomic_add_1d():
-    torch.npu.set_device(0)
     N = 64
 
     a = torch.randn(N, dtype=eval("torch." + dtype)).npu()
@@ -86,7 +85,6 @@ def test_atomic_add_1d():
 
 
 def test_atomic_add_2d():
-    torch.npu.set_device(0)
     M, N = 256, 256
 
     a = torch.randn(M, N, dtype=eval("torch." + dtype)).npu()

--- a/examples/elementwise/atomic_add_dev.py
+++ b/examples/elementwise/atomic_add_dev.py
@@ -68,7 +68,6 @@ def atomic_add_2d_dev(M, N, block_M, block_N, dtype="float32"):
 #  Tests
 # ---------------------------------------------------------------------------
 def test_atomic_add_1d():
-    torch.npu.set_device(0)
     N = 64
 
     a = torch.randn(N, dtype=eval("torch." + dtype)).npu()
@@ -87,7 +86,6 @@ def test_atomic_add_1d():
 
 
 def test_atomic_add_2d():
-    torch.npu.set_device(0)
     M, N = 256, 256
 
     a = torch.randn(M, N, dtype=eval("torch." + dtype)).npu()

--- a/examples/elementwise/example_elementwise_exp2.py
+++ b/examples/elementwise/example_elementwise_exp2.py
@@ -6,7 +6,6 @@ import tilelang
 import tilelang.language as T
 
 torch.manual_seed(1234)
-torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
 M = 16

--- a/examples/elementwise/example_elementwise_log2.py
+++ b/examples/elementwise/example_elementwise_log2.py
@@ -6,7 +6,6 @@ import tilelang
 import tilelang.language as T
 
 torch.manual_seed(1234)
-torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
 M = 16

--- a/examples/elementwise/vec_add_1d.py
+++ b/examples/elementwise/vec_add_1d.py
@@ -41,7 +41,6 @@ def vec_add(N, block_N, dtype="float32"):
 
 
 def test_vec_add():
-    torch.npu.set_device(0)
     func = vec_add(seq_len, seq_len)
     compiled_kernel = tilelang.compile(func, target="npuir")
 

--- a/examples/elementwise/vec_add_2d.py
+++ b/examples/elementwise/vec_add_2d.py
@@ -68,7 +68,6 @@ def run_test(main_args):
 
 
 if __name__ == "__main__":
-    torch.npu.set_device(0)
     tilelang.cache.clear_cache()
     args = parser.parse_args()
     run_test(args)

--- a/examples/elementwise/vec_add_2d_dynamic_shape.py
+++ b/examples/elementwise/vec_add_2d_dynamic_shape.py
@@ -3,7 +3,6 @@ import torch
 import tilelang
 import tilelang.language as T
 
-torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
 @tilelang.jit(target="npuir")

--- a/examples/elementwise/vec_add_2d_multi_buffer.py
+++ b/examples/elementwise/vec_add_2d_multi_buffer.py
@@ -205,6 +205,5 @@ def run_test(main_args):
 
 
 if __name__ == "__main__":
-    torch.npu.set_device(0)
     args = parser.parse_args()
     run_test(args)

--- a/examples/flash_attention/flash_attn_npuir.py
+++ b/examples/flash_attention/flash_attn_npuir.py
@@ -318,7 +318,6 @@ def run_test(main_args):
 
 
 if __name__ == "__main__":
-    torch.npu.set_device(0)
     tilelang.cache.clear_cache()
     args = parser.parse_args()
     run_test(args)

--- a/examples/flash_attention/flash_attn_npuir_dev.py
+++ b/examples/flash_attention/flash_attn_npuir_dev.py
@@ -8,8 +8,6 @@ import tilelang.language as T
 seq_len = 512
 dim = 128
 
-torch.npu.set_device(0)
-
 @tilelang.jit(out_idx=[-1], target="npuir")
 def online_flash_attention(block_M, block_N, block_K, dtype="float16", accum_dtype="float32"):
     shape_q = [seq_len, dim]

--- a/examples/gemm/matmul.py
+++ b/examples/gemm/matmul.py
@@ -3,7 +3,6 @@ import torch
 import tilelang
 import tilelang.language as T
 
-torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
 M = 1024

--- a/examples/gemm/matmul_dynamic_shape.py
+++ b/examples/gemm/matmul_dynamic_shape.py
@@ -3,7 +3,6 @@ import torch
 import tilelang
 import tilelang.language as T
 
-torch.npu.set_device(0)
 tilelang.cache.clear_cache()
 
 @tilelang.jit(target="npuir")

--- a/examples/mixcv/mixcv_mixkernel.py
+++ b/examples/mixcv/mixcv_mixkernel.py
@@ -8,7 +8,6 @@ import tilelang.language as T
 import torch
 import torch_npu
 
-torch.npu.set_device(0)
 
 tilelang.cache.clear_cache()
 

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import subprocess
+import threading
+from pathlib import Path
+from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+
+EXAMPLES_DIR = Path(__file__).resolve().parent
+
+SKIP_FILES = {
+    "run_all.py",
+    "torch_tl_ops/compile/kernels/gemm.py",
+    "torch_tl_ops/compile/kernels/flash_attention.py",
+    "torch_tl_ops/compile/kernels/__init__.py",
+    "torch_tl_ops/compile/precompile.py",
+    "torch_tl_ops/setup.py",
+    "torch_tl_ops/src/ops/base.py",
+    "torch_tl_ops/src/ops/gemm.py",
+    "torch_tl_ops/src/ops/flash_attention.py",
+    "torch_tl_ops/src/ops/__init__.py",
+    "torch_tl_ops/src/kernels/__init__.py",
+    "torch_tl_ops/src/utils/__init__.py",
+    "torch_tl_ops/src/loader.py",
+    "torch_tl_ops/src/registry.py",
+    "torch_tl_ops/src/__init__.py",
+    "torch_tl_ops/tests/__init__.py",
+    "torch_tl_ops/tests/test_flash_attention.py",
+    "torch_tl_ops/tests/test_gemm.py",
+}
+
+SKIP_DIRS = {
+    "torch_tl_ops/src",
+    "torch_tl_ops/compile",
+    "deepseek_v4/inference",
+}
+
+
+@dataclass
+class RunResult:
+    name: str
+    status: str
+    duration: float = 0.0
+    error_msg: str = ""
+    device_id: int = -1
+
+
+def get_npu_device_count():
+    try:
+        import torch
+
+        count = torch.npu.device_count()
+        if count > 0:
+            return count
+    except Exception:
+        pass
+    try:
+        result = subprocess.run(
+            ["npu-smi", "info"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            import re
+
+            matches = re.findall(r"NPU\s+(\d+)", result.stdout)
+            if matches:
+                return len(set(matches))
+    except Exception:
+        pass
+    return 1
+
+
+def collect_examples(base_dir: Path):
+    examples = []
+    for py_file in sorted(base_dir.rglob("*.py")):
+        rel = py_file.relative_to(base_dir)
+        rel_str = str(rel)
+
+        if rel.name == "__init__.py":
+            continue
+        if rel_str in SKIP_FILES:
+            continue
+        if any(rel_str.startswith(d) for d in SKIP_DIRS):
+            continue
+
+        content = py_file.read_text(errors="ignore")
+        if "if __name__" not in content and "def test_" not in content:
+            continue
+
+        examples.append(rel_str)
+    return examples
+
+
+def run_example(rel_path: str, base_dir: Path, device_id: int, timeout: int = 300):
+    abs_path = base_dir / rel_path
+    env = os.environ.copy()
+    env["ASCEND_RT_VISIBLE_DEVICES"] = str(device_id)
+
+    start = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(abs_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(base_dir),
+            env=env,
+        )
+        duration = time.time() - start
+        if proc.returncode == 0:
+            return RunResult(rel_path, "PASSED", duration, "", device_id)
+        else:
+            stderr_lines = proc.stderr.strip().split("\n")
+            tail = (
+                "\n".join(stderr_lines[-5:])
+                if len(stderr_lines) > 5
+                else proc.stderr.strip()
+            )
+            return RunResult(rel_path, "FAILED", duration, tail, device_id)
+    except subprocess.TimeoutExpired:
+        duration = time.time() - start
+        return RunResult(
+            rel_path, "TIMEOUT", duration, f"Exceeded {timeout}s", device_id
+        )
+    except Exception as e:
+        duration = time.time() - start
+        return RunResult(rel_path, "ERROR", duration, str(e), device_id)
+
+
+def print_header(examples, num_devices):
+    width = max(len(e) for e in examples) + 2
+    width = max(width, 40)
+    print(f"{'Example':<{width}} {'Result':<10} {'Time':>8} {'NPU':>4}")
+    print("-" * (width + 26))
+    return width
+
+
+def print_result(result: RunResult, width: int):
+    status_colors = {
+        "PASSED": "\033[92m",
+        "FAILED": "\033[91m",
+        "TIMEOUT": "\033[93m",
+        "ERROR": "\033[91m",
+    }
+    reset = "\033[0m"
+    color = status_colors.get(result.status, "")
+    duration_str = f"{result.duration:.2f}s"
+    device_str = f"NPU{result.device_id}"
+    print(
+        f"{result.name:<{width}} {color}{result.status:<10}{reset} {duration_str:>8} {device_str:>4}"
+    )
+    if result.error_msg and result.status != "PASSED":
+        for line in result.error_msg.split("\n"):
+            print(f"{'':>{width}}   {color}{line}{reset}")
+
+
+def print_summary(results: list[RunResult]):
+    passed = sum(1 for r in results if r.status == "PASSED")
+    failed = sum(1 for r in results if r.status == "FAILED")
+    timeout = sum(1 for r in results if r.status == "TIMEOUT")
+    errored = sum(1 for r in results if r.status == "ERROR")
+    total = len(results)
+    total_time = sum(r.duration for r in results)
+
+    print("\n" + "=" * 60)
+    print(
+        f"Results: {passed} passed, {failed} failed, {timeout} timeout, {errored} error"
+    )
+    print(f"Total: {total} examples in {total_time:.2f}s")
+
+    if failed + timeout + errored > 0:
+        print("\nFailed examples:")
+        for r in results:
+            if r.status != "PASSED":
+                print(f"  {r.status}: {r.name} (NPU{r.device_id})")
+
+    print("=" * 60)
+    return failed + timeout + errored == 0
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run all TileLang NPU examples")
+    parser.add_argument(
+        "--timeout", type=int, default=300, help="Timeout per example (seconds)"
+    )
+    parser.add_argument(
+        "--filter",
+        type=str,
+        default=None,
+        help="Only run examples matching this substring",
+    )
+    parser.add_argument(
+        "--fail-fast", action="store_true", help="Stop on first failure"
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="Max parallel workers (default: NPU device count)",
+    )
+    parser.add_argument(
+        "--sequential",
+        action="store_true",
+        help="Run sequentially on NPU0 (for debugging)",
+    )
+    args = parser.parse_args()
+
+    num_devices = get_npu_device_count()
+
+    if args.sequential:
+        max_workers = 1
+    else:
+        max_workers = args.workers if args.workers is not None else num_devices
+
+    examples = collect_examples(EXAMPLES_DIR)
+    if not examples:
+        print("No examples found.")
+        sys.exit(1)
+
+    if args.filter:
+        examples = [e for e in examples if args.filter in e]
+        if not examples:
+            print(f"No examples matching filter: {args.filter}")
+            sys.exit(1)
+
+    assignments = [(e, i % num_devices) for i, e in enumerate(examples)]
+
+    print(
+        f"Collected {len(examples)} examples, {num_devices} NPU device(s), {max_workers} worker(s)\n"
+    )
+    width = print_header(examples, num_devices)
+
+    results = [None] * len(examples)
+    print_lock = threading.Lock()
+    next_print_idx = [0]
+    fail_fast_event = threading.Event()
+
+    def run_task(idx, rel_path, device_id):
+        if fail_fast_event.is_set():
+            results[idx] = RunResult(rel_path, "SKIPPED", 0.0, "", device_id)
+            with print_lock:
+                _flush_ordered(results, width)
+            return
+
+        result = run_example(rel_path, EXAMPLES_DIR, device_id, timeout=args.timeout)
+        results[idx] = result
+
+        with print_lock:
+            _flush_ordered(results, width)
+
+        if args.fail_fast and result.status != "PASSED":
+            fail_fast_event.set()
+
+    def _flush_ordered(results_list, w):
+        while (
+            next_print_idx[0] < len(results_list)
+            and results_list[next_print_idx[0]] is not None
+        ):
+            print_result(results_list[next_print_idx[0]], w)
+            next_print_idx[0] += 1
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for idx, (rel_path, device_id) in enumerate(assignments):
+            f = executor.submit(run_task, idx, rel_path, device_id)
+            futures.append(f)
+        for f in futures:
+            f.result()
+
+    all_passed = print_summary(results)
+    sys.exit(0 if all_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vectorize/vectorization_in_parallel.py
+++ b/examples/vectorize/vectorization_in_parallel.py
@@ -243,7 +243,6 @@ def test_ternary_simple(v1, v2, v3):
 
 
 if __name__ == "__main__":
-    # torch.npu.set_device(6)
     os.environ['TILELANG_ASCEND_MODE'] = 'Developer'
     # Create random input tensors on the NPU
     v1 = torch.randn(size=[seq_len], dtype=eval("torch." + dtype)).npu()


### PR DESCRIPTION
## Summary

- **Add `examples/run_all.py`**: A unified runner script that automatically discovers, executes, and validates all example scripts with pytest-style output.
- **Reorganize example directory structure**: Move loose top-level examples into categorized subdirectories for better organization.
- **Refactor CI workflow**: Replace the hardcoded example list in `test_npuir_wheel.yml` with `run_all.py --sequential`.
- **Fix fp8 gemm kernel**: Replace `T.Parallel` with `T.serial` in scale accumulation loops to avoid compilation issues in Dev mode.
- **Remove hardcoded `torch.npu.set_device()` calls**: Let device assignment be handled by the runner via `ASCEND_RT_VISIBLE_DEVICES`.

## Changes

### New: `examples/run_all.py`

- Auto-discovers all runnable examples (files with `if __name__` or `def test_`)
- Multi-NPU parallel execution via `ASCEND_RT_VISIBLE_DEVICES` device isolation
- Device count detection: `torch.npu.device_count()` → `npu-smi info` → fallback to 1
- Ordered output with pytest-style table (name / status / time / NPU device)
- Supports `--sequential`, `--workers N`, `--filter`, `--fail-fast`, `--timeout`
- Does **not** inject `TILELANG_ASCEND_MODE` — respects each example's own mode setting

### Refactored: `.github/workflows/test_npuir_wheel.yml`

- Replaced 40-line hardcoded `EXAMPLE_FILES` array + per-file loop with single command: