### PR TITLE
[AscendNPU-IR] Add dynamic tail block handling

### DIFF
--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1732,155 +1732,162 @@ CodeGenTileLangNPUIRDEV::ComputeUBAllocShapeFromDstRange(
 void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
     const tvm::tl::AscendCopy &npuirop, mlir::Value src, mlir::Value dst,
     const SliceRange &srcR, const SliceRange &dstR, mlir::Location loc) {
-  auto dstTensorTy = dst.getType().cast<mlir::RankedTensorType>();
-  auto srcMemrefTy = src.getType().cast<mlir::MemRefType>();
+  auto dst_tensor_type_ori = dst.getType().cast<mlir::RankedTensorType>();
+  auto src_memref_type_ori = src.getType().cast<mlir::MemRefType>();
 
-  // 1. Canonicalize copy rank by collapsing static-1 dimensions
-  llvm::SmallVector<int64_t> ubAllocShape =
-      ComputeUBAllocShapeFromDstRange(dstTensorTy, dstR.sizes);
-  CollapsedDims srcCollapse = CollapseStaticOneDims(
-      srcR.sizes, static_cast<int64_t>(ubAllocShape.size()));
-  auto copySizes = srcCollapse.sizes;
-  auto copyProjected = srcCollapse.projected;
+  // 1) Canonicalize copy rank: drop static-1 dims using src_sizes
+  llvm::SmallVector<int64_t> ub_alloc_shape =
+      ComputeUBAllocShapeFromDstRange(dst_tensor_type_ori, dstR.sizes);
+  CollapsedDims srcC = CollapseStaticOneDims(
+      srcR.sizes, static_cast<int64_t>(ub_alloc_shape.size()));
+  llvm::ArrayRef<mlir::OpFoldResult> copy_sizes = srcC.sizes;
+  llvm::ArrayRef<int64_t> copy_projected = srcC.projected;
 
-  // 2. Create rank-reduced source subview
-  mlir::Value srcView = CreateRankReducedSubviewFromBaseRank(
-      src, srcR.offs, srcR.sizes, srcR.strides, copyProjected, loc);
+  // 2) Build src_view as rank-reduced subview to copy rank
+  mlir::Value src_view = CreateRankReducedSubviewFromBaseRank(
+      src, srcR.offs, srcR.sizes, srcR.strides, copy_projected, loc);
 
-  // 3. Allocate static UB buffer
-  bool hasDynamicDim = false;
-  for (int64_t d : ubAllocShape) {
+  // 3) Alloc UB from dst_range. kDynamic appears only when dst type has a
+  // dynamic dim;
+  //    dst_range dynamic + dst static => static alloc (dst dim as bound),
+  //    dynamic subview.
+  bool has_dynamic = false;
+  for (int64_t d : ub_alloc_shape) {
     if (mlir::ShapedType::isDynamic(d)) {
-      hasDynamicDim = true;
+      has_dynamic = true;
       break;
     }
   }
-  ICHECK(!hasDynamicDim) << "Dynamic UB allocation is not supported";
+  ICHECK(!has_dynamic)
+      << "dst with dynamic dimension(s) not supported for UB alloc";
 
-  mlir::Value baseUb = CreateStaticLocalUB(
-      ubAllocShape, dstTensorTy.getElementType(), loc);
-  auto ubTy = baseUb.getType().cast<mlir::MemRefType>();
-  bool rankMatches = static_cast<int64_t>(copySizes.size()) == ubTy.getRank();
-  llvm::SmallVector<mlir::OpFoldResult> fullSizes(ubTy.getRank(), builder.getIndexAttr(1));
+  mlir::Value base_ub = CreateStaticLocalUB(
+      ub_alloc_shape, src_memref_type_ori.getElementType(), loc);
 
-  // 4. Create UB target subview matching copy rank
-  mlir::Value ubView;
-  if (rankMatches) {
-    for (unsigned i = 0; i < copySizes.size(); ++i) {
-      fullSizes[i] = copySizes[i];
+  // 4) Create ub_view matching copy rank
+  mlir::Value ub_view;
+  auto ubTy = base_ub.getType().cast<mlir::MemRefType>();
+  // Full copy sizes per dimension for tail block detection
+  llvm::SmallVector<mlir::OpFoldResult> full_sizes(ubTy.getRank(), builder.getIndexAttr(1));
+
+  if ((int64_t)copy_sizes.size() == ubTy.getRank()) {
+    for (unsigned i = 0; i < copy_sizes.size(); ++i) {
+      full_sizes[i] = copy_sizes[i];
     }
-    if (OpFoldResultsEqualStaticShape(copySizes, ubAllocShape)) {
-      ubView = baseUb;
+
+    if (OpFoldResultsEqualStaticShape(copy_sizes, ub_alloc_shape)) {
+      ub_view = base_ub;
     } else {
-      ubView = CreateSameRankDynamicSubview(baseUb, copySizes, loc);
+      ub_view = CreateSameRankDynamicSubview(base_ub, copy_sizes, loc);
     }
   } else {
-    CollapsedDims dstCollapse =
+    CollapsedDims dstC =
         CollapseStaticOneDims(dstR.sizes, static_cast<int64_t>(ubTy.getRank()));
 
     llvm::SmallVector<mlir::OpFoldResult> fullOffsets(ubTy.getRank(),
                                                       builder.getIndexAttr(0));
     llvm::SmallVector<mlir::OpFoldResult> fullStrides(ubTy.getRank(),
                                                       builder.getIndexAttr(1));
+    llvm::SmallVector<mlir::OpFoldResult> fullSizes(ubTy.getRank(),
+                                                    builder.getIndexAttr(1));
 
-    if (static_cast<int64_t>(dstCollapse.keptIdx.size()) == static_cast<int64_t>(copySizes.size()) &&
-        static_cast<int64_t>(dstCollapse.keptIdx.size()) <= ubTy.getRank()) {
-      for (unsigned k = 0; k < dstCollapse.keptIdx.size(); ++k) {
-        unsigned idx = dstCollapse.keptIdx[k];
-        if (idx < static_cast<unsigned>(ubTy.getRank()))
-          fullSizes[idx] = copySizes[k];
+    if ((int64_t)dstC.keptIdx.size() == (int64_t)copy_sizes.size() &&
+        (int64_t)dstC.keptIdx.size() <= ubTy.getRank()) {
+      for (unsigned k = 0; k < dstC.keptIdx.size(); ++k) {
+        unsigned idx = dstC.keptIdx[k];
+        if (idx < (unsigned)ubTy.getRank())
+          fullSizes[idx] = copy_sizes[k];
       }
     } else {
       for (unsigned k = 0;
-           k < copySizes.size() && k < static_cast<unsigned>(ubTy.getRank()); ++k) {
-        fullSizes[k] = copySizes[k];
+           k < copy_sizes.size() && k < (unsigned)ubTy.getRank(); ++k) {
+        fullSizes[k] = copy_sizes[k];
       }
     }
 
-    ubView = CreateRankReducedSubviewFromBaseRank(
-        baseUb, fullOffsets, fullSizes, fullStrides, copyProjected, loc);
+    full_sizes = fullSizes;
+    ub_view = CreateRankReducedSubviewFromBaseRank(
+        base_ub, fullOffsets, fullSizes, fullStrides, copy_projected, loc);
   }
 
-  // Pre-zero full UB for tail blocks
-  mlir::Type elemTy = ubTy.getElementType();
-  mlir::TypedAttr zeroAttr = builder.getZeroAttr(elemTy);
-  mlir::Value zeroVal = builder.create<mlir::arith::ConstantOp>(loc, zeroAttr);
+  // Tail block pre-zero
+  mlir::Type elem_type = ubTy.getElementType();
+  mlir::TypedAttr zero_attr = builder.getZeroAttr(elem_type);
+  mlir::Value zero_val = builder.create<mlir::arith::ConstantOp>(loc, zero_attr);
 
-  mlir::Value needPad = builder.create<mlir::arith::ConstantOp>(
+  mlir::Value need_pad = builder.create<mlir::arith::ConstantOp>(
       loc, builder.getBoolAttr(false));
 
-  for (int64_t dim = 0; dim < ubTy.getRank(); ++dim) {
-    int64_t staticFullSize = ubAllocShape[dim];
-    if (mlir::ShapedType::isDynamic(staticFullSize))
+  for (int64_t dim_idx = 0; dim_idx < ubTy.getRank(); ++dim_idx) {
+    int64_t static_full_size = ub_alloc_shape[dim_idx];
+    if (mlir::ShapedType::isDynamic(static_full_size)) {
       continue;
+    }
 
-    mlir::Value copyDimVal;
-    auto sizeOfr = fullSizes[dim];
-    if (auto attr = sizeOfr.dyn_cast<mlir::Attribute>()) {
+    mlir::Value copy_dim_val;
+    auto size_ofr = full_sizes[dim_idx];
+    if (auto attr = size_ofr.dyn_cast<mlir::Attribute>()) {
       int64_t val = attr.cast<mlir::IntegerAttr>().getInt();
-      copyDimVal = builder.create<mlir::arith::ConstantIndexOp>(loc, val);
+      copy_dim_val = builder.create<mlir::arith::ConstantIndexOp>(loc, val);
     } else {
-      copyDimVal = sizeOfr.get<mlir::Value>();
-      if (copyDimVal.getType().isIndex()) {
-        copyDimVal = builder.create<mlir::arith::IndexCastOp>(
-            loc, builder.getIndexType(), copyDimVal);
+      copy_dim_val = size_ofr.get<mlir::Value>();
+      if (copy_dim_val.getType().isInteger(32)) {
+        copy_dim_val = builder.create<mlir::arith::IndexCastOp>(
+            loc, builder.getIndexType(), copy_dim_val);
       }
     }
 
-    mlir::Value fullSizeVal = builder.create<mlir::arith::ConstantIndexOp>(loc, staticFullSize);
-    mlir::Value isTail = builder.create<mlir::arith::CmpIOp>(
-        loc, mlir::arith::CmpIPredicate::slt, copyDimVal, fullSizeVal);
-    needPad = builder.create<mlir::arith::OrIOp>(loc, needPad, isTail);
+    mlir::Value full_size_val = builder.create<mlir::arith::ConstantIndexOp>(loc, static_full_size);
+    mlir::Value is_tail = builder.create<mlir::arith::CmpIOp>(
+        loc, mlir::arith::CmpIPredicate::slt, copy_dim_val, full_size_val);
+    need_pad = builder.create<mlir::arith::OrIOp>(loc, need_pad, is_tail);
   }
 
-  auto padIfOp = builder.create<mlir::scf::IfOp>(loc, needPad, /*addElseRegion=*/false);
-  padIfOp->setAttr("hivm.unlikely_condition", builder.getUnitAttr());
+  auto pad_if_op = builder.create<mlir::scf::IfOp>(loc, need_pad, /*addElseRegion=*/false);
+  pad_if_op->setAttr("hivm.unlikely_condition", builder.getUnitAttr());
   {
     mlir::OpBuilder::InsertionGuard guard(builder);
-    builder.setInsertionPointToStart(&padIfOp.getThenRegion().front());
-    builder.create<mlir::linalg::FillOp>(loc, zeroVal, baseUb);
+    builder.setInsertionPointToStart(&pad_if_op.getThenRegion().front());
+    builder.create<mlir::linalg::FillOp>(loc, zero_val, base_ub);
   }
 
-  // 5. Execute memory copy
-  builder.create<mlir::memref::CopyOp>(loc, srcView, ubView);
+  // 5) Copy
+  builder.create<mlir::memref::CopyOp>(loc, src_view, ub_view);
 
-  // Fast path: full static UB to tensor (skip expand + insert)
-  bool canUseFullUb = rankMatches;
-  if (canUseFullUb) {
+  // Fast path: full UB to tensor when rank matches and all dst offsets are 0
+  bool rank_matches = (int64_t)copy_sizes.size() == ubTy.getRank();
+  bool can_use_full_ub = rank_matches;
+  if (can_use_full_ub) {
     for (auto &off : dstR.offs) {
       if (auto attr = off.dyn_cast<mlir::Attribute>()) {
         int64_t val = attr.cast<mlir::IntegerAttr>().getInt();
         if (val != 0) {
-          canUseFullUb = false;
+          can_use_full_ub = false;
           break;
         }
       } else {
-        canUseFullUb = false;
+        can_use_full_ub = false;
         break;
       }
     }
   }
 
-  if (canUseFullUb) {
-    mlir::Value fullTensor = builder.create<mlir::bufferization::ToTensorOp>(
-        loc, baseUb, /*restrict=*/true, /*writable=*/true);
-    mlir::Value casted = CreateCastIfTypeMismatch(fullTensor, dst);
+  if (can_use_full_ub) {
+    mlir::Value full_tensor = builder.create<mlir::bufferization::ToTensorOp>(
+        loc, base_ub, /*restrict=*/true, /*writable=*/true);
+    mlir::Value casted = CreateCastIfTypeMismatch(full_tensor, dst);
     SetVarValue(npuirop.dst, casted);
     return;
   }
 
-  // Fallback path: subview to tensor + shape normalization + insert
-  mlir::Value loadedTensor = builder.create<mlir::bufferization::ToTensorOp>(
-      loc, ubView, /*restrict=*/true, /*writable=*/false);
+  // 6) ToTensor
+  mlir::Value loaded_tensor = builder.create<mlir::bufferization::ToTensorOp>(
+      loc, ub_view, /*restrict=*/true, /*writable=*/false);
 
-  mlir::Value castedTensor = CreateCastIfTypeMismatch(loadedTensor, dst);
+  // 7) Insert slice with optional cast
+  mlir::Value result = InsertSliceWithCast(loaded_tensor, dst, dstR, loc);
 
-  mlir::Value result = InsertSlice(
-      castedTensor, dst,
-      const_cast<llvm::SmallVector<mlir::OpFoldResult>&>(dstR.offs),
-      const_cast<llvm::SmallVector<mlir::OpFoldResult>&>(dstR.sizes),
-      const_cast<llvm::SmallVector<mlir::OpFoldResult>&>(dstR.strides));
-
+  // 8) SetVarValue
   SetVarValue(npuirop.dst, result);
 }
 

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1732,88 +1732,155 @@ CodeGenTileLangNPUIRDEV::ComputeUBAllocShapeFromDstRange(
 void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
     const tvm::tl::AscendCopy &npuirop, mlir::Value src, mlir::Value dst,
     const SliceRange &srcR, const SliceRange &dstR, mlir::Location loc) {
-  auto dst_tensor_type_ori = dst.getType().cast<mlir::RankedTensorType>();
-  auto src_memref_type_ori = src.getType().cast<mlir::MemRefType>();
+  auto dstTensorTy = dst.getType().cast<mlir::RankedTensorType>();
+  auto srcMemrefTy = src.getType().cast<mlir::MemRefType>();
 
-  // 1) Canonicalize copy rank: drop static-1 dims using src_sizes
-  llvm::SmallVector<int64_t> ub_alloc_shape =
-      ComputeUBAllocShapeFromDstRange(dst_tensor_type_ori, dstR.sizes);
-  CollapsedDims srcC = CollapseStaticOneDims(
-      srcR.sizes, static_cast<int64_t>(ub_alloc_shape.size()));
-  llvm::ArrayRef<mlir::OpFoldResult> copy_sizes = srcC.sizes;
-  llvm::ArrayRef<int64_t> copy_projected = srcC.projected;
+  // 1. Canonicalize copy rank by collapsing static-1 dimensions
+  llvm::SmallVector<int64_t> ubAllocShape =
+      ComputeUBAllocShapeFromDstRange(dstTensorTy, dstR.sizes);
+  CollapsedDims srcCollapse = CollapseStaticOneDims(
+      srcR.sizes, static_cast<int64_t>(ubAllocShape.size()));
+  auto copySizes = srcCollapse.sizes;
+  auto copyProjected = srcCollapse.projected;
 
-  // 2) Build src_view as rank-reduced subview to copy rank
-  mlir::Value src_view = CreateRankReducedSubviewFromBaseRank(
-      src, srcR.offs, srcR.sizes, srcR.strides, copy_projected, loc);
+  // 2. Create rank-reduced source subview
+  mlir::Value srcView = CreateRankReducedSubviewFromBaseRank(
+      src, srcR.offs, srcR.sizes, srcR.strides, copyProjected, loc);
 
-  // 3) Alloc UB from dst_range. kDynamic appears only when dst type has a
-  // dynamic dim;
-  //    dst_range dynamic + dst static => static alloc (dst dim as bound),
-  //    dynamic subview.
-  bool has_dynamic = false;
-  for (int64_t d : ub_alloc_shape) {
+  // 3. Allocate static UB buffer
+  bool hasDynamicDim = false;
+  for (int64_t d : ubAllocShape) {
     if (mlir::ShapedType::isDynamic(d)) {
-      has_dynamic = true;
+      hasDynamicDim = true;
       break;
     }
   }
-  ICHECK(!has_dynamic)
-      << "dst with dynamic dimension(s) not supported for UB alloc";
+  ICHECK(!hasDynamicDim) << "Dynamic UB allocation is not supported";
 
-  mlir::Value base_ub = CreateStaticLocalUB(
-      ub_alloc_shape, src_memref_type_ori.getElementType(), loc);
+  mlir::Value baseUb = CreateStaticLocalUB(
+      ubAllocShape, dstTensorTy.getElementType(), loc);
+  auto ubTy = baseUb.getType().cast<mlir::MemRefType>();
+  bool rankMatches = static_cast<int64_t>(copySizes.size()) == ubTy.getRank();
+  llvm::SmallVector<mlir::OpFoldResult> fullSizes(ubTy.getRank(), builder.getIndexAttr(1));
 
-  // 4) Create ub_view matching copy rank
-  mlir::Value ub_view;
-  auto ubTy = base_ub.getType().cast<mlir::MemRefType>();
-
-  if ((int64_t)copy_sizes.size() == ubTy.getRank()) {
-    if (OpFoldResultsEqualStaticShape(copy_sizes, ub_alloc_shape)) {
-      ub_view = base_ub;
+  // 4. Create UB target subview matching copy rank
+  mlir::Value ubView;
+  if (rankMatches) {
+    for (unsigned i = 0; i < copySizes.size(); ++i) {
+      fullSizes[i] = copySizes[i];
+    }
+    if (OpFoldResultsEqualStaticShape(copySizes, ubAllocShape)) {
+      ubView = baseUb;
     } else {
-      ub_view = CreateSameRankDynamicSubview(base_ub, copy_sizes, loc);
+      ubView = CreateSameRankDynamicSubview(baseUb, copySizes, loc);
     }
   } else {
-    CollapsedDims dstC =
+    CollapsedDims dstCollapse =
         CollapseStaticOneDims(dstR.sizes, static_cast<int64_t>(ubTy.getRank()));
 
     llvm::SmallVector<mlir::OpFoldResult> fullOffsets(ubTy.getRank(),
                                                       builder.getIndexAttr(0));
     llvm::SmallVector<mlir::OpFoldResult> fullStrides(ubTy.getRank(),
                                                       builder.getIndexAttr(1));
-    llvm::SmallVector<mlir::OpFoldResult> fullSizes(ubTy.getRank(),
-                                                    builder.getIndexAttr(1));
 
-    if ((int64_t)dstC.keptIdx.size() == (int64_t)copy_sizes.size() &&
-        (int64_t)dstC.keptIdx.size() <= ubTy.getRank()) {
-      for (unsigned k = 0; k < dstC.keptIdx.size(); ++k) {
-        unsigned idx = dstC.keptIdx[k];
-        if (idx < (unsigned)ubTy.getRank())
-          fullSizes[idx] = copy_sizes[k];
+    if (static_cast<int64_t>(dstCollapse.keptIdx.size()) == static_cast<int64_t>(copySizes.size()) &&
+        static_cast<int64_t>(dstCollapse.keptIdx.size()) <= ubTy.getRank()) {
+      for (unsigned k = 0; k < dstCollapse.keptIdx.size(); ++k) {
+        unsigned idx = dstCollapse.keptIdx[k];
+        if (idx < static_cast<unsigned>(ubTy.getRank()))
+          fullSizes[idx] = copySizes[k];
       }
     } else {
       for (unsigned k = 0;
-           k < copy_sizes.size() && k < (unsigned)ubTy.getRank(); ++k) {
-        fullSizes[k] = copy_sizes[k];
+           k < copySizes.size() && k < static_cast<unsigned>(ubTy.getRank()); ++k) {
+        fullSizes[k] = copySizes[k];
       }
     }
 
-    ub_view = CreateRankReducedSubviewFromBaseRank(
-        base_ub, fullOffsets, fullSizes, fullStrides, copy_projected, loc);
+    ubView = CreateRankReducedSubviewFromBaseRank(
+        baseUb, fullOffsets, fullSizes, fullStrides, copyProjected, loc);
   }
 
-  // 5) Copy
-  builder.create<mlir::memref::CopyOp>(loc, src_view, ub_view);
+  // Pre-zero full UB for tail blocks
+  mlir::Type elemTy = ubTy.getElementType();
+  mlir::TypedAttr zeroAttr = builder.getZeroAttr(elemTy);
+  mlir::Value zeroVal = builder.create<mlir::arith::ConstantOp>(loc, zeroAttr);
 
-  // 6) ToTensor
-  mlir::Value loaded_tensor = builder.create<mlir::bufferization::ToTensorOp>(
-      loc, ub_view, /*restrict=*/true, /*writable=*/false);
+  mlir::Value needPad = builder.create<mlir::arith::ConstantOp>(
+      loc, builder.getBoolAttr(false));
 
-  // 7) Insert slice with optional cast
-  mlir::Value result = InsertSliceWithCast(loaded_tensor, dst, dstR, loc);
+  for (int64_t dim = 0; dim < ubTy.getRank(); ++dim) {
+    int64_t staticFullSize = ubAllocShape[dim];
+    if (mlir::ShapedType::isDynamic(staticFullSize))
+      continue;
 
-  // 8) SetVarValue
+    mlir::Value copyDimVal;
+    auto sizeOfr = fullSizes[dim];
+    if (auto attr = sizeOfr.dyn_cast<mlir::Attribute>()) {
+      int64_t val = attr.cast<mlir::IntegerAttr>().getInt();
+      copyDimVal = builder.create<mlir::arith::ConstantIndexOp>(loc, val);
+    } else {
+      copyDimVal = sizeOfr.get<mlir::Value>();
+      if (copyDimVal.getType().isInteger(32)) {
+        copyDimVal = builder.create<mlir::arith::IndexCastOp>(
+            loc, builder.getIndexType(), copyDimVal);
+      }
+    }
+
+    mlir::Value fullSizeVal = builder.create<mlir::arith::ConstantIndexOp>(loc, staticFullSize);
+    mlir::Value isTail = builder.create<mlir::arith::CmpIOp>(
+        loc, mlir::arith::CmpIPredicate::slt, copyDimVal, fullSizeVal);
+    needPad = builder.create<mlir::arith::OrIOp>(loc, needPad, isTail);
+  }
+
+  auto padIfOp = builder.create<mlir::scf::IfOp>(loc, needPad, /*addElseRegion=*/false);
+  padIfOp->setAttr("hivm.unlikely_condition", builder.getUnitAttr());
+  {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(&padIfOp.getThenRegion().front());
+    builder.create<mlir::linalg::FillOp>(loc, zeroVal, baseUb);
+  }
+
+  // 5. Execute memory copy
+  builder.create<mlir::memref::CopyOp>(loc, srcView, ubView);
+
+  // Fast path: full static UB to tensor (skip expand + insert)
+  bool canUseFullUb = rankMatches;
+  if (canUseFullUb) {
+    for (auto &off : dstR.offs) {
+      if (auto attr = off.dyn_cast<mlir::Attribute>()) {
+        int64_t val = attr.cast<mlir::IntegerAttr>().getInt();
+        if (val != 0) {
+          canUseFullUb = false;
+          break;
+        }
+      } else {
+        canUseFullUb = false;
+        break;
+      }
+    }
+  }
+
+  if (canUseFullUb) {
+    mlir::Value fullTensor = builder.create<mlir::bufferization::ToTensorOp>(
+        loc, baseUb, /*restrict=*/true, /*writable=*/true);
+    mlir::Value casted = CreateCastIfTypeMismatch(fullTensor, dst);
+    SetVarValue(npuirop.dst, casted);
+    return;
+  }
+
+  // Fallback path: subview to tensor + shape normalization + insert
+  mlir::Value loadedTensor = builder.create<mlir::bufferization::ToTensorOp>(
+      loc, ubView, /*restrict=*/true, /*writable=*/false);
+
+  mlir::Value castedTensor = CreateCastIfTypeMismatch(loadedTensor, dst);
+
+  mlir::Value result = InsertSlice(
+      castedTensor, dst,
+      const_cast<llvm::SmallVector<mlir::OpFoldResult>&>(dstR.offs),
+      const_cast<llvm::SmallVector<mlir::OpFoldResult>&>(dstR.sizes),
+      const_cast<llvm::SmallVector<mlir::OpFoldResult>&>(dstR.strides));
+
   SetVarValue(npuirop.dst, result);
 }
 

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -1821,7 +1821,7 @@ void CodeGenTileLangNPUIRDEV::EmitCopyMemrefToTensor(
       copyDimVal = builder.create<mlir::arith::ConstantIndexOp>(loc, val);
     } else {
       copyDimVal = sizeOfr.get<mlir::Value>();
-      if (copyDimVal.getType().isInteger(32)) {
+      if (copyDimVal.getType().isIndex()) {
         copyDimVal = builder.create<mlir::arith::IndexCastOp>(
             loc, builder.getIndexType(), copyDimVal);
       }


### PR DESCRIPTION
Add dynamic tail block handling
ir of matmul:
module attributes {hivm.module_core_type = #hivm.module_core_type<AIC>, memref.memref_as_ptr} {
  func.func @flash_attention(%arg0: memref<?xi8> {hacc.arg_type = #hacc.arg_type<sync_block_lock>}, %arg1: memref<?xi8> {hacc.arg_type = #hacc.arg_type<workspace>}, %arg2: memref<?xf16>, %arg3: memref<?xf16>, %arg4: memref<?xf32>, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, global_kernel = "local", mix_mode = "aic", parallel_mode = "simd"} {
    %c1_i32 = arith.constant 1 : i32
    %0 = arith.index_cast %c1_i32 : i32 to index
    %c128_i32 = arith.constant 128 : i32
    %1 = arith.muli %c128_i32, %c1_i32 : i32
    %2 = arith.index_cast %1 : i32 to index
    %reinterpret_cast = memref.reinterpret_cast %arg2 to offset: [0], sizes: [544, 128], strides: [%2, %0] : memref<?xf16> to memref<544x128xf16, strided<[128, 1]>>
    %c544_i32 = arith.constant 544 : i32
    %3 = arith.muli %c544_i32, %c1_i32 : i32
    %4 = arith.index_cast %3 : i32 to index
    %reinterpret_cast_0 = memref.reinterpret_cast %arg4 to offset: [0], sizes: [544, 544], strides: [%4, %0] : memref<?xf32> to memref<544x544xf32, strided<[544, 1]>>
    %reinterpret_cast_1 = memref.reinterpret_cast %arg3 to offset: [0], sizes: [544, 128], strides: [%2, %0] : memref<?xf16> to memref<544x128xf16, strided<[128, 1]>>
    %5 = hivm.hir.get_block_idx -> i64
    %6 = arith.trunci %5 : i64 to i32
    %7 = tensor.empty() : tensor<64x128xf16>
    %c64_i32 = arith.constant 64 : i32
    %8 = arith.muli %6, %c64_i32 : i32
    %9 = arith.index_cast %8 : i32 to index
    %10 = arith.subi %c544_i32, %8 : i32
    %11 = arith.minsi %c64_i32, %10 : i32
    %12 = arith.index_cast %11 : i32 to index
    %subview = memref.subview %reinterpret_cast[%9, 0] [%12, 128] [1, 1] : memref<544x128xf16, strided<[128, 1]>> to memref<?x128xf16, strided<[128, 1], offset: ?>>
    %alloc = memref.alloc() : memref<64x128xf16>
    %subview_2 = memref.subview %alloc[0, 0] [%12, 128] [1, 1] : memref<64x128xf16> to memref<?x128xf16, strided<[128, 1]>>
    %cst = arith.constant 0.000000e+00 : f16
    %false = arith.constant false
    %c64 = arith.constant 64 : index
    %13 = arith.cmpi slt, %12, %c64 : index
    %14 = arith.ori %false, %13 : i1
    %c128 = arith.constant 128 : index
    %c128_3 = arith.constant 128 : index
    %15 = arith.cmpi slt, %c128, %c128_3 : index
    %16 = arith.ori %14, %15 : i1
    scf.if %16 {
      linalg.fill ins(%cst : f16) outs(%alloc : memref<64x128xf16>)
    } {hivm.unlikely_condition}
    memref.copy %subview, %subview_2 : memref<?x128xf16, strided<[128, 1], offset: ?>> to memref<?x128xf16, strided<[128, 1]>>
    %17 = bufferization.to_tensor %alloc restrict writable : memref<64x128xf16>
    %c0_i32 = arith.constant 0 : i32
    %c9_i32 = arith.constant 9 : i32
    %c1_i32_4 = arith.constant 1 : i32
    %18 = scf.for %arg11 = %c0_i32 to %c9_i32 step %c1_i32_4 iter_args(%arg12 = %17) -> (tensor<64x128xf16>)  : i32 {
      %19 = tensor.empty() : tensor<64x128xf16>
      %20 = tensor.empty() : tensor<64x64xf32>
      %c64_i32_5 = arith.constant 64 : i32
      %21 = arith.muli %arg11, %c64_i32_5 : i32
      %22 = arith.index_cast %21 : i32 to index
      %c544_i32_6 = arith.constant 544 : i32
      %23 = arith.subi %c544_i32_6, %21 : i32
      %24 = arith.minsi %c64_i32_5, %23 : i32
      %25 = arith.index_cast %24 : i32 to index
      %subview_7 = memref.subview %reinterpret_cast_1[%22, 0] [%25, 128] [1, 1] : memref<544x128xf16, strided<[128, 1]>> to memref<?x128xf16, strided<[128, 1], offset: ?>>
      %alloc_8 = memref.alloc() : memref<64x128xf16>
      %subview_9 = memref.subview %alloc_8[0, 0] [%25, 128] [1, 1] : memref<64x128xf16> to memref<?x128xf16, strided<[128, 1]>>
      %cst_10 = arith.constant 0.000000e+00 : f16
      %false_11 = arith.constant false
      %c64_12 = arith.constant 64 : index
      %26 = arith.cmpi slt, %25, %c64_12 : index
      %27 = arith.ori %false_11, %26 : i1
      %c128_13 = arith.constant 128 : index
      %c128_14 = arith.constant 128 : index
      %28 = arith.cmpi slt, %c128_13, %c128_14 : index
      %29 = arith.ori %27, %28 : i1
      scf.if %29 {
        linalg.fill ins(%cst_10 : f16) outs(%alloc_8 : memref<64x128xf16>)
      } {hivm.unlikely_condition}
      memref.copy %subview_7, %subview_9 : memref<?x128xf16, strided<[128, 1], offset: ?>> to memref<?x128xf16, strided<[128, 1]>>
      %30 = bufferization.to_tensor %alloc_8 restrict writable : memref<64x128xf16>
      %true = arith.constant true
      %31 = arith.index_cast %c64_i32_5 : i32 to index
      %c128_i32_15 = arith.constant 128 : i32
      %32 = arith.index_cast %c128_i32_15 : i32 to index
      %33 = hivm.hir.mmadL1 {b_transpose} ins(%arg12, %30, %true, %31, %31, %32 : tensor<64x128xf16>, tensor<64x128xf16>, i1, index, index, index) outs(%20 : tensor<64x64xf32>) -> tensor<64x64xf32>
      %34 = arith.muli %6, %c64_i32_5 : i32
      %35 = arith.subi %c544_i32_6, %34 : i32
      %36 = arith.minsi %c64_i32_5, %35 : i32
      %37 = arith.index_cast %36 : i32 to index
      %38 = arith.index_cast %34 : i32 to index
      %extracted_slice = tensor.extract_slice %33[0, 0] [%37, %25] [1, 1] : tensor<64x64xf32> to tensor<?x?xf32>
      %subview_16 = memref.subview %reinterpret_cast_0[%38, %22] [%37, %25] [1, 1] : memref<544x544xf32, strided<[544, 1]>> to memref<?x?xf32, strided<[544, 1], offset: ?>>
      bufferization.materialize_in_destination %extracted_slice in writable %subview_16 : (tensor<?x?xf32>, memref<?x?xf32, strided<[544, 1], offset: ?>>) -> ()
      scf.yield %arg12 : tensor<64x128xf16>
    }
    return
  }
}