### PR TITLE
add ada_layer_norm and zero

### DIFF
--- a/examples/norm/ada_layer_norm_and_zero.py
+++ b/examples/norm/ada_layer_norm_and_zero.py
@@ -1,4 +1,14 @@
-# backup
+"""Adaptive LayerNorm (AdaLN / AdaLN-Zero) kernel using TileLang.
+
+AdaLN:      y = scale * LayerNorm(x) + shift
+AdaLN-Zero: y = gate * (scale * LayerNorm(x) + shift)
+
+The `has_gate` parameter controls the variant:
+- has_gate=False → AdaLN
+- has_gate=True  → AdaLN-Zero
+
+The input N must be an integer multiple of block_n.
+"""
 
 import tilelang
 import tilelang.language as T
@@ -251,10 +261,10 @@ def ada_layer_norm_zero_ref(x, scale, shift, gate, eps):
 
 
 def run_adaln_test(
-    M=4096,
-    N=5000,
+    M=1024,
+    N=16384,
     block_m=2,
-    block_n=4096,
+    block_n=2048,
     eps=1e-5,
     dtype="float16",
     device="npu",

--- a/examples/norm/ada_layer_norm_and_zero.py
+++ b/examples/norm/ada_layer_norm_and_zero.py
@@ -7,7 +7,6 @@ The `has_gate` parameter controls the variant:
 - has_gate=False → AdaLN
 - has_gate=True  → AdaLN-Zero
 
-The input N must be an integer multiple of block_n.
 """
 
 import tilelang
@@ -18,24 +17,19 @@ import os
 import torch.nn.functional as F
 
 
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
-
-
 def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
     N_inv = 1.0 / float(N)
 
     @tilelang.jit(out_idx=[3] if not has_gate else [4], target="npuir")
     def _func(block_m, block_n):
-        N_padded = _align_up(N, block_n)
         if not has_gate:
 
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
-                scale: T.Tensor[(M, N_padded), dtype],
-                shift: T.Tensor[(M, N_padded), dtype],
-                y: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
+                scale: T.Tensor[(M, N), dtype],
+                shift: T.Tensor[(M, N), dtype],
+                y: T.Tensor[(M, N), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), is_npu=True) as (pid_m, _):
                     x_tile = T.alloc_ub((block_m, block_n), "float32")
@@ -53,21 +47,34 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
+                        remain_n = T.min(block_n, N - offset_n)
                         T.clear(x_tile)
 
                         T.copy(
                             x[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            x_tile[0:tile_size_m, 0:block_n],
+                            x_tile[0:tile_size_m, 0:remain_n],
                         )
-                        T.reduce_sum(x_tile, red_tmp, dim=1)
-                        T.vadd(mean_val, red_tmp, mean_val)
+                        T.npuir_reduce(
+                            x_tile,
+                            mean_val,
+                            dims=1,
+                            reduce_mode="sum",
+                            size=[tile_size_m, remain_n],
+                            clear=False,
+                        )
 
                         T.vmul(x_tile, x_tile, x_tile)
-                        T.reduce_sum(x_tile, red_tmp, dim=1)
-                        T.vadd(var_val, red_tmp, var_val)
+                        T.npuir_reduce(
+                            x_tile,
+                            var_val,
+                            dims=1,
+                            reduce_mode="sum",
+                            size=[tile_size_m, remain_n],
+                            clear=False,
+                        )
 
                     T.vmul(mean_val, N_inv, mean_val)
                     T.vmul(var_val, N_inv, var_val)
@@ -81,40 +88,43 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
+                        remain_n = T.min(block_n, N - offset_n)
                         T.clear(x_tile)
 
                         T.copy(
                             x[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            x_tile[0:tile_size_m, 0:block_n],
+                            x_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vsub(x_tile, mean_val, x_tile)
                         T.vmul(x_tile, rstd, x_tile)
 
+                        T.clear(scale_tile)
                         T.copy(
                             scale[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:block_n],
+                            scale_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
+                        T.clear(scale_tile)
                         T.copy(
                             shift[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:block_n],
+                            scale_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vadd(x_tile, scale_tile, x_tile)
                         T.copy(
-                            x_tile[0:tile_size_m, 0:block_n],
+                            x_tile[0:tile_size_m, 0:remain_n],
                             y[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
                         )
 
@@ -123,11 +133,11 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
 
             @T.prim_func
             def main_gated(
-                x: T.Tensor[(M, N_padded), dtype],
-                scale: T.Tensor[(M, N_padded), dtype],
-                shift: T.Tensor[(M, N_padded), dtype],
-                gate: T.Tensor[(M, N_padded), dtype],
-                y: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
+                scale: T.Tensor[(M, N), dtype],
+                shift: T.Tensor[(M, N), dtype],
+                gate: T.Tensor[(M, N), dtype],
+                y: T.Tensor[(M, N), dtype],
             ):
 
                 with T.Kernel(
@@ -149,21 +159,34 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
+                        remain_n = T.min(block_n, N - offset_n)
                         T.clear(x_tile)
 
                         T.copy(
                             x[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            x_tile[0:tile_size_m, 0:block_n],
+                            x_tile[0:tile_size_m, 0:remain_n],
                         )
-                        T.reduce_sum(x_tile, red_tmp, dim=1)
-                        T.vadd(mean_val, red_tmp, mean_val)
+                        T.npuir_reduce(
+                            x_tile,
+                            mean_val,
+                            dims=1,
+                            reduce_mode="sum",
+                            size=[tile_size_m, remain_n],
+                            clear=False,
+                        )
 
                         T.vmul(x_tile, x_tile, x_tile)
-                        T.reduce_sum(x_tile, red_tmp, dim=1)
-                        T.vadd(var_val, red_tmp, var_val)
+                        T.npuir_reduce(
+                            x_tile,
+                            var_val,
+                            dims=1,
+                            reduce_mode="sum",
+                            size=[tile_size_m, remain_n],
+                            clear=False,
+                        )
 
                     T.vmul(mean_val, N_inv, mean_val)
                     T.vmul(var_val, N_inv, var_val)
@@ -177,50 +200,54 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
+                        remain_n = T.min(block_n, N - offset_n)
                         T.clear(x_tile)
 
                         T.copy(
                             x[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            x_tile[0:tile_size_m, 0:block_n],
+                            x_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vsub(x_tile, mean_val, x_tile)
                         T.vmul(x_tile, rstd, x_tile)
 
+                        T.clear(scale_tile)
                         T.copy(
                             scale[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:block_n],
+                            scale_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
+                        T.clear(scale_tile)
                         T.copy(
                             shift[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:block_n],
+                            scale_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vadd(x_tile, scale_tile, x_tile)
 
+                        T.clear(scale_tile)
                         T.copy(
                             gate[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:block_n],
+                            scale_tile[0:tile_size_m, 0:remain_n],
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
                         T.copy(
-                            x_tile[0:tile_size_m, 0:block_n],
+                            x_tile[0:tile_size_m, 0:remain_n],
                             y[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + block_n,
+                                offset_n : offset_n + remain_n,
                             ],
                         )
 
@@ -262,7 +289,7 @@ def ada_layer_norm_zero_ref(x, scale, shift, gate, eps):
 
 def run_adaln_test(
     M=1024,
-    N=16384,
+    N=16385,
     block_m=2,
     block_n=2048,
     eps=1e-5,
@@ -271,8 +298,6 @@ def run_adaln_test(
     atol=1e-2,
     rtol=1e-2,
 ):
-    n_padded = _align_up(N, block_n)
-
     torch_dtype = {
         "float16": torch.float16,
         "float32": torch.float32,
@@ -281,29 +306,27 @@ def run_adaln_test(
 
     # Inputs
     x = torch.zeros(
-        (M, n_padded),
+        (M, N),
         dtype=torch_dtype,
         device=device,
     )
     x[:, :N] = torch.randn((M, N), dtype=torch_dtype, device=device)
-    scale = torch.randn((M, n_padded), dtype=torch_dtype, device=device)
+    scale = torch.randn((M, N), dtype=torch_dtype, device=device)
     shift = torch.randn(
-        (M, n_padded),
+        (M, N),
         dtype=torch_dtype,
         device=device,
     )
 
     # Reference
-    y_ref = ada_layer_norm_ref(x[:, :N], scale[:, :N], shift[:, :N], eps)
-    y_ref_padded = torch.zeros_like(x)
-    y_ref_padded[:, :N] = y_ref
+    y_ref = ada_layer_norm_ref(x, scale, shift, eps)
 
     program = _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False)
     y = program(block_m, block_n)(x, scale, shift)
 
     torch.testing.assert_close(
         y[:M, :N].float(),
-        y_ref_padded[:M, :N].float(),
+        y_ref[:M, :N].float(),
         atol=atol,
         rtol=rtol,
     )
@@ -321,8 +344,6 @@ def run_adaln_zero_test(
     atol=1e-2,
     rtol=1e-2,
 ):
-    n_padded = _align_up(N, block_n)
-
     torch_dtype = {
         "float16": torch.float16,
         "float32": torch.float32,
@@ -331,7 +352,7 @@ def run_adaln_zero_test(
 
     # Inputs
     x = torch.zeros(
-        (M, n_padded),
+        (M, N),
         dtype=torch_dtype,
         device=device,
     )
@@ -341,28 +362,24 @@ def run_adaln_zero_test(
         device=device,
     )
     scale = torch.randn(
-        (M, n_padded),
+        (M, N),
         dtype=torch_dtype,
         device=device,
     )
     shift = torch.randn(
-        (M, n_padded),
+        (M, N),
         dtype=torch_dtype,
         device=device,
     )
     gate = torch.randn(
-        (M, n_padded),
+        (M, N),
         dtype=torch_dtype,
         device=device,
     )
     gate = torch.clamp(gate, min=-1.0, max=1.0)
 
     # Reference
-    y_ref = ada_layer_norm_zero_ref(
-        x[:, :N], scale[:, :N], shift[:, :N], gate[:, :N], eps
-    )
-    y_ref_padded = torch.zeros_like(x)
-    y_ref_padded[:, :N] = y_ref
+    y_ref = ada_layer_norm_zero_ref(x, scale, shift, gate, eps)
 
     # TileLang kernel
     program = _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=True)
@@ -371,7 +388,7 @@ def run_adaln_zero_test(
     # Compare
     torch.testing.assert_close(
         y[:M, :N].float(),
-        y_ref_padded[:M, :N].float(),
+        y_ref[:M, :N].float(),
         atol=atol,
         rtol=rtol,
     )

--- a/examples/norm/ada_layer_norm_and_zero.py
+++ b/examples/norm/ada_layer_norm_and_zero.py
@@ -48,7 +48,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
                         remain_n = T.min(block_n, N - offset_n)
-                        T.clear(x_tile)
 
                         T.copy(
                             x[
@@ -89,7 +88,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
                         remain_n = T.min(block_n, N - offset_n)
-                        T.clear(x_tile)
 
                         T.copy(
                             x[
@@ -101,7 +99,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         T.vsub(x_tile, mean_val, x_tile)
                         T.vmul(x_tile, rstd, x_tile)
 
-                        T.clear(scale_tile)
                         T.copy(
                             scale[
                                 offset_m : offset_m + tile_size_m,
@@ -111,7 +108,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
-                        T.clear(scale_tile)
                         T.copy(
                             shift[
                                 offset_m : offset_m + tile_size_m,
@@ -160,7 +156,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
                         remain_n = T.min(block_n, N - offset_n)
-                        T.clear(x_tile)
 
                         T.copy(
                             x[
@@ -201,7 +196,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
                         remain_n = T.min(block_n, N - offset_n)
-                        T.clear(x_tile)
 
                         T.copy(
                             x[
@@ -213,7 +207,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         T.vsub(x_tile, mean_val, x_tile)
                         T.vmul(x_tile, rstd, x_tile)
 
-                        T.clear(scale_tile)
                         T.copy(
                             scale[
                                 offset_m : offset_m + tile_size_m,
@@ -223,7 +216,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
-                        T.clear(scale_tile)
                         T.copy(
                             shift[
                                 offset_m : offset_m + tile_size_m,
@@ -233,7 +225,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         )
                         T.vadd(x_tile, scale_tile, x_tile)
 
-                        T.clear(scale_tile)
                         T.copy(
                             gate[
                                 offset_m : offset_m + tile_size_m,
@@ -289,7 +280,7 @@ def ada_layer_norm_zero_ref(x, scale, shift, gate, eps):
 
 def run_adaln_test(
     M=1024,
-    N=16385,
+    N=16384,
     block_m=2,
     block_n=2048,
     eps=1e-5,

--- a/examples/norm/ada_layer_norm_and_zero.py
+++ b/examples/norm/ada_layer_norm_and_zero.py
@@ -1,0 +1,383 @@
+# backup
+
+import tilelang
+import tilelang.language as T
+import torch
+
+import os
+import torch.nn.functional as F
+
+
+def _align_up(n: int, alignment: int) -> int:
+    return ((n + alignment - 1) // alignment) * alignment
+
+
+def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
+    N_inv = 1.0 / float(N)
+
+    @tilelang.jit(out_idx=[4] if not has_gate else [5], target="npuir")
+    def _func(block_m, block_n):
+        N_padded = _align_up(N, block_n)
+        if not has_gate:
+
+            @T.prim_func
+            def main(
+                x: T.Tensor[(M, N_padded), dtype],
+                scale: T.Tensor[(M, N_padded), dtype],
+                shift: T.Tensor[(M, N_padded), dtype],
+                _dummy: T.Tensor[(1,), dtype],
+                y: T.Tensor[(M, N_padded), dtype],
+            ):
+                with T.Kernel(T.ceildiv(M, block_m), is_npu=True) as (pid_m, _):
+                    x_tile = T.alloc_ub((block_m, block_n), "float32")
+                    scale_tile = T.alloc_ub((block_m, block_n), "float32")
+
+                    mean_val = T.alloc_ub((block_m, 1), "float32")
+                    var_val = T.alloc_ub((block_m, 1), "float32")
+                    red_tmp = T.alloc_ub((block_m, 1), "float32")
+                    rstd = T.alloc_ub((block_m, 1), "float32")
+
+                    T.clear(mean_val)
+                    T.clear(var_val)
+
+                    for no in T.serial(T.ceildiv(N, block_n)):
+                        offset_m = pid_m * block_m
+                        tile_size_m = T.min(block_m, M - pid_m * block_m)
+                        offset_n = no * block_n
+                        tile_size_n = T.min(block_n, N - no * block_n)
+                        T.clear(x_tile)
+
+                        T.copy(
+                            x[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + block_n,
+                            ],
+                            x_tile[0:tile_size_m, 0:block_n],
+                        )
+                        T.reduce_sum(x_tile, red_tmp, dim=1)
+                        T.vadd(mean_val, red_tmp, mean_val)
+
+                        T.vmul(x_tile, x_tile, x_tile)
+                        T.reduce_sum(x_tile, red_tmp, dim=1)
+                        T.vadd(var_val, red_tmp, var_val)
+
+                    T.vmul(mean_val, N_inv, mean_val)
+                    T.vmul(var_val, N_inv, var_val)
+
+                    T.vmul(mean_val, mean_val, red_tmp)
+                    T.vsub(var_val, red_tmp, var_val)
+                    T.vadd(var_val, eps, var_val)
+                    T.vrsqrt(var_val, rstd)
+
+                    for no in T.serial(T.ceildiv(N, block_n)):
+                        offset_m = pid_m * block_m
+                        tile_size_m = T.min(block_m, M - pid_m * block_m)
+                        offset_n = no * block_n
+                        tile_size_n = T.min(block_n, N - no * block_n)
+                        T.clear(x_tile)
+
+                        T.copy(
+                            x[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + block_n,
+                            ],
+                            x_tile[0:tile_size_m, 0:block_n],
+                        )
+                        T.vsub(x_tile, mean_val, x_tile)
+                        T.vmul(x_tile, rstd, x_tile)
+
+                        T.copy(
+                            scale[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                        )
+                        T.vmul(x_tile, scale_tile, x_tile)
+
+                        T.copy(
+                            shift[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                        )
+                        T.vadd(x_tile, scale_tile, x_tile)
+                        T.copy(
+                            x_tile[0:tile_size_m, 0:tile_size_n],
+                            y[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                        )
+
+            return main
+        else:
+
+            @T.prim_func
+            def main_gated(
+                x: T.Tensor[(M, N_padded), dtype],
+                scale: T.Tensor[(M, N_padded), dtype],
+                shift: T.Tensor[(M, N_padded), dtype],
+                gate: T.Tensor[(M, N_padded), dtype],
+                _dummy: T.Tensor[(1,), dtype],
+                y: T.Tensor[(M, N_padded), dtype],
+            ):
+
+                with T.Kernel(
+                    T.ceildiv(M, block_m),
+                    is_npu=True,
+                ) as (pid_m, _):
+                    x_tile = T.alloc_ub((block_m, block_n), "float32")
+                    scale_tile = T.alloc_ub((block_m, block_n), "float32")
+
+                    mean_val = T.alloc_ub((block_m, 1), "float32")
+                    var_val = T.alloc_ub((block_m, 1), "float32")
+                    red_tmp = T.alloc_ub((block_m, 1), "float32")
+                    rstd = T.alloc_ub((block_m, 1), "float32")
+
+                    T.clear(mean_val)
+                    T.clear(var_val)
+
+                    for no in T.serial(T.ceildiv(N, block_n)):
+                        offset_m = pid_m * block_m
+                        tile_size_m = T.min(block_m, M - pid_m * block_m)
+                        offset_n = no * block_n
+                        tile_size_n = T.min(block_n, N - no * block_n)
+                        T.clear(x_tile)
+
+                        T.copy(
+                            x[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + block_n,
+                            ],
+                            x_tile[0:tile_size_m, 0:block_n],
+                        )
+                        T.reduce_sum(x_tile, red_tmp, dim=1)
+                        T.vadd(mean_val, red_tmp, mean_val)
+
+                        T.vmul(x_tile, x_tile, x_tile)
+                        T.reduce_sum(x_tile, red_tmp, dim=1)
+                        T.vadd(var_val, red_tmp, var_val)
+
+                    T.vmul(mean_val, N_inv, mean_val)
+                    T.vmul(var_val, N_inv, var_val)
+
+                    T.vmul(mean_val, mean_val, red_tmp)
+                    T.vsub(var_val, red_tmp, var_val)
+                    T.vadd(var_val, eps, var_val)
+                    T.vrsqrt(var_val, rstd)
+
+                    for no in T.serial(T.ceildiv(N, block_n)):
+                        offset_m = pid_m * block_m
+                        tile_size_m = T.min(block_m, M - pid_m * block_m)
+                        offset_n = no * block_n
+                        tile_size_n = T.min(block_n, N - no * block_n)
+                        T.clear(x_tile)
+
+                        T.copy(
+                            x[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + block_n,
+                            ],
+                            x_tile[0:tile_size_m, 0:block_n],
+                        )
+                        T.vsub(x_tile, mean_val, x_tile)
+                        T.vmul(x_tile, rstd, x_tile)
+
+                        T.copy(
+                            scale[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                        )
+                        T.vmul(x_tile, scale_tile, x_tile)
+
+                        T.copy(
+                            shift[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                        )
+                        T.vadd(x_tile, scale_tile, x_tile)
+
+                        T.copy(
+                            gate[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                        )
+                        T.vmul(x_tile, scale_tile, x_tile)
+
+                        T.copy(
+                            x_tile[0:tile_size_m, 0:tile_size_n],
+                            y[
+                                offset_m : offset_m + tile_size_m,
+                                offset_n : offset_n + tile_size_n,
+                            ],
+                        )
+
+            return main_gated
+
+    return _func
+
+
+def ada_layer_norm_ref(x, scale, shift, eps):
+    N = x.shape[-1]
+
+    y = F.layer_norm(
+        x.float(),
+        # x,
+        (N,),
+        weight=None,
+        bias=None,
+        eps=eps,
+    )
+
+    y = y * scale.float() + shift.float()
+    return y.to(x.dtype)
+
+
+def ada_layer_norm_zero_ref(x, scale, shift, gate, eps):
+    N = x.shape[-1]
+
+    y = F.layer_norm(
+        x.float(),
+        (N,),
+        weight=None,
+        bias=None,
+        eps=eps,
+    )
+
+    y = gate.float() * (y * scale.float() + shift.float())
+    return y.to(x.dtype)
+
+
+def run_adaln_test(
+    M=4096,
+    N=5000,
+    block_m=2,
+    block_n=4096,
+    eps=1e-5,
+    dtype="float16",
+    device="npu",
+    atol=1e-2,
+    rtol=1e-2,
+):
+    n_padded = _align_up(N, block_n)
+
+    torch_dtype = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+    }[dtype]
+
+    # Inputs
+    x = torch.zeros(
+        (M, n_padded),
+        dtype=torch_dtype,
+        device=device,
+    )
+    x[:, :N] = torch.randn((M, N), dtype=torch_dtype, device=device)
+    scale = torch.randn((M, n_padded), dtype=torch_dtype, device=device)
+    shift = torch.randn(
+        (M, n_padded),
+        dtype=torch_dtype,
+        device=device,
+    )
+
+    # Reference
+    y_ref = ada_layer_norm_ref(x[:, :N], scale[:, :N], shift[:, :N], eps)
+    y_ref_padded = torch.zeros_like(x)
+    y_ref_padded[:, :N] = y_ref
+
+    program = _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False)
+    dummy = torch.empty(1, dtype=torch_dtype, device=device)
+    y = program(block_m, block_n)(x, scale, shift, dummy)
+
+    torch.testing.assert_close(
+        y[:M, :N].float(),
+        y_ref_padded[:M, :N].float(),
+        atol=atol,
+        rtol=rtol,
+    )
+    print("\033[32;1mAdaLN Pass!\033[0m")
+
+
+def run_adaln_zero_test(
+    M=4096,
+    N=4096,
+    block_m=4,
+    block_n=4096,
+    eps=1e-5,
+    dtype="float16",
+    device="npu",
+    atol=1e-2,
+    rtol=1e-2,
+):
+    n_padded = _align_up(N, block_n)
+
+    torch_dtype = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+    }[dtype]
+
+    # Inputs
+    x = torch.zeros(
+        (M, n_padded),
+        dtype=torch_dtype,
+        device=device,
+    )
+    x[:, :N] = torch.randn(
+        (M, N),
+        dtype=torch_dtype,
+        device=device,
+    )
+    scale = torch.randn(
+        (M, n_padded),
+        dtype=torch_dtype,
+        device=device,
+    )
+    shift = torch.randn(
+        (M, n_padded),
+        dtype=torch_dtype,
+        device=device,
+    )
+    gate = torch.randn(
+        (M, n_padded),
+        dtype=torch_dtype,
+        device=device,
+    )
+    gate = torch.clamp(gate, min=-1.0, max=1.0)
+
+    # Reference
+    y_ref = ada_layer_norm_zero_ref(
+        x[:, :N], scale[:, :N], shift[:, :N], gate[:, :N], eps
+    )
+    y_ref_padded = torch.zeros_like(x)
+    y_ref_padded[:, :N] = y_ref
+
+    # TileLang kernel
+    program = _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=True)
+    dummy = torch.empty(1, dtype=torch_dtype, device=device)
+    y = program(block_m, block_n)(x, scale, shift, gate, dummy)
+
+    # Compare
+    torch.testing.assert_close(
+        y[:M, :N].float(),
+        y_ref_padded[:M, :N].float(),
+        atol=atol,
+        rtol=rtol,
+    )
+    print("\033[32;1mAdaLN_Zero Pass!\033[0m")
+
+
+if __name__ == "__main__":
+    os.environ["TILELANG_ASCEND_MODE"] = "Dev"
+    tilelang.cache.clear_cache()
+    run_adaln_test()
+    run_adaln_zero_test()

--- a/examples/norm/ada_layer_norm_and_zero.py
+++ b/examples/norm/ada_layer_norm_and_zero.py
@@ -15,7 +15,7 @@ def _align_up(n: int, alignment: int) -> int:
 def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
     N_inv = 1.0 / float(N)
 
-    @tilelang.jit(out_idx=[4] if not has_gate else [5], target="npuir")
+    @tilelang.jit(out_idx=[3] if not has_gate else [4], target="npuir")
     def _func(block_m, block_n):
         N_padded = _align_up(N, block_n)
         if not has_gate:
@@ -25,7 +25,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                 x: T.Tensor[(M, N_padded), dtype],
                 scale: T.Tensor[(M, N_padded), dtype],
                 shift: T.Tensor[(M, N_padded), dtype],
-                _dummy: T.Tensor[(1,), dtype],
                 y: T.Tensor[(M, N_padded), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), is_npu=True) as (pid_m, _):
@@ -44,7 +43,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
-                        tile_size_n = T.min(block_n, N - no * block_n)
                         T.clear(x_tile)
 
                         T.copy(
@@ -73,7 +71,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
-                        tile_size_n = T.min(block_n, N - no * block_n)
                         T.clear(x_tile)
 
                         T.copy(
@@ -89,25 +86,25 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         T.copy(
                             scale[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                            scale_tile[0:tile_size_m, 0:block_n],
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
                         T.copy(
                             shift[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                            scale_tile[0:tile_size_m, 0:block_n],
                         )
                         T.vadd(x_tile, scale_tile, x_tile)
                         T.copy(
-                            x_tile[0:tile_size_m, 0:tile_size_n],
+                            x_tile[0:tile_size_m, 0:block_n],
                             y[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
                         )
 
@@ -120,7 +117,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                 scale: T.Tensor[(M, N_padded), dtype],
                 shift: T.Tensor[(M, N_padded), dtype],
                 gate: T.Tensor[(M, N_padded), dtype],
-                _dummy: T.Tensor[(1,), dtype],
                 y: T.Tensor[(M, N_padded), dtype],
             ):
 
@@ -143,7 +139,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
-                        tile_size_n = T.min(block_n, N - no * block_n)
                         T.clear(x_tile)
 
                         T.copy(
@@ -172,7 +167,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         offset_m = pid_m * block_m
                         tile_size_m = T.min(block_m, M - pid_m * block_m)
                         offset_n = no * block_n
-                        tile_size_n = T.min(block_n, N - no * block_n)
                         T.clear(x_tile)
 
                         T.copy(
@@ -188,35 +182,35 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                         T.copy(
                             scale[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                            scale_tile[0:tile_size_m, 0:block_n],
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
                         T.copy(
                             shift[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                            scale_tile[0:tile_size_m, 0:block_n],
                         )
                         T.vadd(x_tile, scale_tile, x_tile)
 
                         T.copy(
                             gate[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
-                            scale_tile[0:tile_size_m, 0:tile_size_n],
+                            scale_tile[0:tile_size_m, 0:block_n],
                         )
                         T.vmul(x_tile, scale_tile, x_tile)
 
                         T.copy(
-                            x_tile[0:tile_size_m, 0:tile_size_n],
+                            x_tile[0:tile_size_m, 0:block_n],
                             y[
                                 offset_m : offset_m + tile_size_m,
-                                offset_n : offset_n + tile_size_n,
+                                offset_n : offset_n + block_n,
                             ],
                         )
 
@@ -295,8 +289,7 @@ def run_adaln_test(
     y_ref_padded[:, :N] = y_ref
 
     program = _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False)
-    dummy = torch.empty(1, dtype=torch_dtype, device=device)
-    y = program(block_m, block_n)(x, scale, shift, dummy)
+    y = program(block_m, block_n)(x, scale, shift)
 
     torch.testing.assert_close(
         y[:M, :N].float(),
@@ -363,8 +356,7 @@ def run_adaln_zero_test(
 
     # TileLang kernel
     program = _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=True)
-    dummy = torch.empty(1, dtype=torch_dtype, device=device)
-    y = program(block_m, block_n)(x, scale, shift, gate, dummy)
+    y = program(block_m, block_n)(x, scale, shift, gate)
 
     # Compare
     torch.testing.assert_close(


### PR DESCRIPTION
# ada_layer_norm 性能数据

| shape | tile | TileLang算子性能数据(μs) | vector_ratio | scalar_ratio | mte2_ratio | mte3_ratio | ASCEND C性能 | 性能百分比 |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| (1024 1024) | (32 256) | 10.5562 | 0.827 | 0.128 | 0.255 | 0.172 | 31.2588 | 2.961179212 |
| (1024 4096) | (4 4096) | 33.0886 | 0.682 | 0.154 | 0.253 | 0.068 | 56.8459 | 1.717990486 |
| (1024 10240) | (4 2048) | 74.4974 | 0.839 | 0.264 | 0.469 | 0.116 | 101.3426 | 1.360350831 |
| (1024 16384) | (2 2048) | 132.0426 | 0.827 | 0.38 | 0.764 | 0.185 | 140.4069 | 1.063345466 |
| (1024 20480) | (2 4096) | 153.2028 | 0.755 | 0.165 | 0.629 | 0.112 | 186.8173 | 1.219411786 |
| (2048 4096) | (2 4096) | 67.1134 | 0.742 | 0.211 | 0.299 | 0.076 | 108.8904 | 1.622483736 |
| (64 32768) | (2 4096) | 17.2482 | 0.886 | 0.218 | 0.296 | 0.123 | 25.6347 | 1.48622465 |
| (4096 4096) | (4 4096) | 137.6588 | 0.61 | 0.114 | 0.349 | 0.072 | 211.6031 | 1.537156361 |