### PR TITLE
[AscendNPU-IR] [FlashQLA ] add FlashQLA kernel `tilelang_get_warmup_chunks_kernel`

### DIFF
--- a/examples/flash_qla/tilelang_get_warmup_chunks.py
+++ b/examples/flash_qla/tilelang_get_warmup_chunks.py
@@ -1,0 +1,257 @@
+import os
+
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+DTYPE_TO_STR = {
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.int16: "int16",
+    torch.int8: "int8",
+    torch.uint8: "uint8",
+    torch.bool: "bool",
+}
+
+
+@tilelang.jit(target="npuir")
+def tilelang_get_warmup_chunks(
+    num_heads,
+    chunk_size,
+    threshold,
+    accum_dtype,
+    g_dtype,
+    mask_dtype,
+    seqlen_dtype,
+    reverse,
+):
+    batch_size = T.dynamic("batch_size")
+    num_tokens = T.dynamic("num_tokens")
+    num_cu_seqlens = T.dynamic("num_cu_seqlens")
+
+    @T.prim_func
+    def tilelang_get_warmup_chunks_kernel(
+        g: T.Tensor([1, num_tokens, num_heads], dtype=g_dtype),
+        ht_mask: T.Tensor([batch_size], dtype=mask_dtype),
+        cu_seqlens: T.Tensor([num_cu_seqlens], dtype=seqlen_dtype),
+        num_warmup_chunks: T.Tensor([batch_size, num_heads], dtype=seqlen_dtype),
+        fallback_mask: T.Tensor([batch_size, num_heads], dtype=mask_dtype),
+    ):
+        with T.Kernel(batch_size, is_npu=True) as (bb, _):
+            ht_mask_shared = T.alloc_shared((1,), mask_dtype)
+            T.copy(ht_mask[bb], ht_mask_shared)
+            n_fragment = T.alloc_fragment((num_heads,), seqlen_dtype)
+            f_fragment = T.alloc_fragment((num_heads,), "float16")
+
+            if ht_mask_shared[0] == 0:
+                g_shared = T.alloc_shared((num_heads,), g_dtype)
+                g_cumsum = T.alloc_fragment((num_heads,), accum_dtype)
+
+                sentinel = T.alloc_fragment((num_heads,), seqlen_dtype)
+                cmp_lt = T.alloc_fragment((num_heads,), "bool")
+                cmp_eq = T.alloc_fragment((num_heads,), "bool")
+                cond = T.alloc_fragment((num_heads,), "bool")
+                tmp1 = T.alloc_fragment((num_heads,), seqlen_dtype)
+
+                f_cmp = T.alloc_fragment((num_heads,), "bool")
+                zero_full = T.alloc_fragment((num_heads,), "float16")
+                one_full = T.alloc_fragment((num_heads,), "float16")
+
+                sentinel_f32 = T.alloc_fragment((num_heads,), "float32")
+                n_fragment_f32 = T.alloc_fragment((num_heads,), "float32")
+
+                T.clear(g_cumsum)
+
+                num_iters = (cu_seqlens[bb + 1] - cu_seqlens[bb]) // chunk_size
+                sentinel_val = num_iters + 1
+                T.vbrc(sentinel_val, sentinel)
+                T.vbrc(sentinel_val, n_fragment)
+                T.vbrc(T.float32(sentinel_val), sentinel_f32)
+                T.vbrc(T.int32(0), tmp1)
+
+                start_idx = cu_seqlens[bb] + chunk_size - 1
+                end_idx = cu_seqlens[bb + 1] - 1
+                for i_s in T.serial(num_iters):
+                    if reverse:
+                        row_idx = start_idx + i_s * chunk_size
+                        T.copy(g[0, row_idx, 0:num_heads], g_shared)
+                    else:
+                        row_idx = end_idx - i_s * chunk_size
+                        T.copy(g[0, row_idx, 0:num_heads], g_shared)
+
+                    if g_dtype != accum_dtype:
+                        g_shared_cast = T.alloc_shared((num_heads,), accum_dtype)
+                        T.vcast(g_shared, g_shared_cast)
+                        T.vadd(g_cumsum, g_shared_cast, g_cumsum)
+                    else:
+                        T.vadd(g_cumsum, g_shared, g_cumsum)
+
+                    T.vcmp(g_cumsum, T.float32(threshold), cmp_lt, "lt")
+                    T.vcmp(n_fragment, sentinel, cmp_eq, "eq")
+                    T.vand(cmp_lt, cmp_eq, cond)
+                    T.vadd(tmp1, 1, tmp1)
+                    T.vselect(cond, tmp1, n_fragment, n_fragment)
+
+                T.vbrc(T.float16(0), zero_full)
+                T.vbrc(T.float16(1), one_full)
+                T.vcast(n_fragment, n_fragment_f32)
+                T.vcmp(n_fragment_f32, sentinel_f32, f_cmp, "lt")
+                T.vselect(f_cmp, zero_full, one_full, f_fragment)
+
+                T.vbrc(num_iters, tmp1)
+                T.vselect(f_cmp, n_fragment, tmp1, n_fragment)
+
+                T.copy(n_fragment, num_warmup_chunks[bb, 0])
+                T.copy(f_fragment, fallback_mask[bb, 0])
+            else:
+                T.vbrc(T.int32(0), n_fragment)
+                T.copy(n_fragment, num_warmup_chunks[bb, 0])
+
+    return tilelang_get_warmup_chunks_kernel
+
+
+def get_warmup_chunks(
+    g: torch.Tensor,  # [1, num_total_tokens, num_v_heads]
+    cu_seqlens: torch.Tensor,  # [cp_real_batch_size + 1]
+    ht_mask: torch.Tensor,  # [cp_real_batch_size]
+    chunk_size: int = 64,
+    threshold: float = -10.0,
+    reverse: bool = False,
+):
+    batch_size, num_tokens, num_heads = g.shape
+    real_batch_size = ht_mask.shape[0]
+    assert cu_seqlens.shape[0] == real_batch_size + 1
+    assert batch_size == 1
+    assert chunk_size == 64
+
+    tilelang_get_warmup_chunks_kernel = tilelang_get_warmup_chunks(
+        num_heads=num_heads,
+        chunk_size=chunk_size,
+        threshold=threshold,
+        accum_dtype="float32",
+        g_dtype=DTYPE_TO_STR[g.dtype],
+        mask_dtype=DTYPE_TO_STR[ht_mask.dtype],
+        seqlen_dtype=DTYPE_TO_STR[cu_seqlens.dtype],
+        reverse=reverse,
+    )
+    num_warmup_chunks = torch.empty(
+        [real_batch_size, num_heads], dtype=cu_seqlens.dtype, device=cu_seqlens.device
+    )
+    fallback_mask = torch.empty(
+        [real_batch_size, num_heads], dtype=ht_mask.dtype, device=cu_seqlens.device
+    )
+    tilelang_get_warmup_chunks_kernel(
+        g, ht_mask, cu_seqlens, num_warmup_chunks, fallback_mask
+    )
+
+    return num_warmup_chunks, fallback_mask
+
+
+def get_warmup_chunks_torch_ref(
+    g, ht_mask, cu_seqlens, num_heads, chunk_size, threshold, reverse
+):
+    batch_size = ht_mask.shape[0]
+    num_warmup_chunks = torch.zeros(
+        (batch_size, num_heads), dtype=cu_seqlens.dtype, device="cpu"
+    )
+    fallback_mask = torch.zeros(
+        (batch_size, num_heads), dtype=ht_mask.dtype, device="cpu"
+    )
+
+    g_cpu = g.cpu()
+    ht_mask_cpu = ht_mask.cpu()
+    cu_seqlens_cpu = cu_seqlens.cpu()
+
+    n_iters_list = [0] * batch_size
+    for b in range(batch_size):
+        if ht_mask_cpu[b] != 0:
+            num_warmup_chunks[b, :] = 0
+            fallback_mask[b, :] = 0
+        else:
+            seq_start = cu_seqlens_cpu[b].item()
+            seq_end = cu_seqlens_cpu[b + 1].item()
+            n_iters = (seq_end - seq_start) // chunk_size
+            n_iters_list[b] = n_iters
+
+            g_cumsum = torch.zeros(num_heads, dtype=torch.float32)
+            n_frag = torch.full((num_heads,), n_iters, dtype=cu_seqlens.dtype)
+            f_frag = torch.ones(num_heads, dtype=ht_mask.dtype)
+
+            for s in range(n_iters):
+                idx = seq_end - s * chunk_size - 1
+                if reverse:
+                    idx = seq_start + (s + 1) * chunk_size - 1
+
+                g_val = g_cpu[0, idx, :]
+                g_cumsum += g_val
+                for h in range(num_heads):
+                    if g_cumsum[h] < threshold and n_frag[h] == n_iters:
+                        n_frag[h] = s + 1
+                        f_frag[h] = 0
+
+            num_warmup_chunks[b, :] = n_frag
+            fallback_mask[b, :] = f_frag
+    print(n_iters_list)
+    return num_warmup_chunks, fallback_mask
+
+
+def test_get_warmup_chunks():
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+    tilelang.cache.clear_cache()
+
+    batch_size = 48
+    num_tokens = 1024 * 128
+    num_heads = 256
+    chunk_size = 64
+    threshold = -10.0
+
+    torch.manual_seed(42)
+
+    g = (torch.randn((1, num_tokens, num_heads), dtype=torch.float16) * 0.8).npu()
+    ht_mask = torch.randint(0, 2, (batch_size,), dtype=torch.int8).npu()
+
+    num_chunks = num_tokens // chunk_size
+    rand_boundaries = torch.sort(torch.randint(1, num_chunks, (batch_size - 1,)))[0]
+    cu_seqlens = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32),
+            (rand_boundaries * chunk_size).to(torch.int32),
+            torch.tensor([num_tokens], dtype=torch.int32),
+        ]
+    ).npu()
+
+    reverse = True
+    ref_num_warmup, ref_fallback = get_warmup_chunks_torch_ref(
+        g, ht_mask, cu_seqlens, num_heads, chunk_size, threshold, reverse
+    )
+
+    num_warmup_chunks_out, fallback_mask_out = get_warmup_chunks(
+        g, cu_seqlens, ht_mask, chunk_size, threshold, reverse
+    )
+
+    torch.testing.assert_close(
+        num_warmup_chunks_out.cpu(), ref_num_warmup, rtol=0, atol=0
+    )
+    print("num_warmup_chunks check passed!")
+
+    torch.testing.assert_close(
+        fallback_mask_out.cpu().to(ref_fallback.dtype), ref_fallback, rtol=0, atol=0
+    )
+    print("fallback_mask check passed!")
+
+    for _ in range(10):
+        num_warmup_chunks_out, fallback_mask_out = get_warmup_chunks(
+            g, cu_seqlens, ht_mask, chunk_size, threshold
+        )
+
+    print("\033[92mAll check passed!\033[0m")
+
+
+if __name__ == "__main__":
+    test_get_warmup_chunks()


### PR DESCRIPTION

**msprof性能数据**
Op Name | Task Type | Task Duration(us) | Block Dim | Input Shapes | Input Data Types | aiv_time(us) | aiv_total_cycles | aiv_vec_time(us) | aiv_vec_ratio | aiv_scalar_time(us) | aiv_scalar_ratio | aiv_mte2_time(us) | aiv_mte2_ratio | aiv_mte3_time(us) | aiv_mte3_ratio | aiv_icache_miss_rate | cube_utilization(%)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 54.4 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 27.286 | 1080525 | 3.584 | 0.131 | 4.055 | 0.149 | 12.845 | 0.471 | 0.296 | 0.011 | 0.027 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 31.94 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 16.373 | 648382 | 3.585 | 0.219 | 1.904 | 0.116 | 6.026 | 0.368 | 0.263 | 0.016 | 0.026 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 28.6 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 11.145 | 441352 | 3.578 | 0.321 | 3.026 | 0.272 | 5.4 | 0.485 | 0.266 | 0.024 | 0.005 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 31.98 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.986 | 435060 | 3.577 | 0.326 | 2.824 | 0.257 | 5.454 | 0.496 | 0.268 | 0.024 | 0.004 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 30.04 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.749 | 425653 | 3.577 | 0.333 | 2.553 | 0.238 | 5.494 | 0.511 | 0.286 | 0.027 | 0.002 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 27.74 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.307 | 408163 | 3.576 | 0.347 | 2.769 | 0.269 | 4.867 | 0.472 | 0.273 | 0.026 | 0.001 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 27.42 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.281 | 407120 | 3.575 | 0.348 | 2.616 | 0.254 | 4.997 | 0.486 | 0.278 | 0.027 | 0 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 27.82 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.309 | 408234 | 3.575 | 0.347 | 2.819 | 0.273 | 4.831 | 0.469 | 0.269 | 0.026 | 0 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 31 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.342 | 409524 | 3.575 | 0.346 | 2.728 | 0.264 | 4.958 | 0.479 | 0.265 | 0.026 | 0 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 29.22 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.245 | 405710 | 3.575 | 0.349 | 2.611 | 0.255 | 4.961 | 0.484 | 0.283 | 0.028 | 0 | 0
tilelang_get_warmup_chunks_kernel | AI_VECTOR_CORE | 27.52 | 48 | "1,131072,256;48;49;48,256;48,256" | FLOAT16;INT8;INT32;INT32;INT8 | 10.316 | 408504 | 3.575 | 0.347 | 2.789 | 0.27 | 4.867 | 0.472 | 0.269 | 0.026 | 0 | 0



# 算法逻辑

## 总体流程图

``` mermaid
sequenceDiagram
    participant Host as CPU主机
    participant Thread as 线程
    participant Mem as 全局内存
    
    Host->>Thread: 启动Kernel<br/>batch_size

    par 每个Thread独立执行
        Thread->>Mem: 读取 ht_mask[bb]
        alt ht_mask[bb] == True
            Thread->>Mem: 直接写入0
        else ht_mask[bb] == False
            Thread->>Mem: 读取 cu_seqlens[bb], cu_seqlens[bb+1]
            Thread->>Thread: 计算 num_iters
            Thread->>Thread: 初始化寄存器片段
            
            loop i_s = 0 to num_iters-1
                Thread->>Mem: 读取 g[0, seq_end - i_s*chunk_size - 1, :]
                Thread->>Thread: 累积和计算
                Thread->>Thread: 阈值判断与记录
            end
            
            Thread->>Mem: 写入 num_warmup_chunks[bb, :]
            Thread->>Mem: 写入 fallback_mask[bb, :]
        end
    end
    
    Thread-->>Host: Kernel执行完成
```

## 单batch流程图

``` mermaid
flowchart TD
    Start([开始处理bb])
    
    CheckMask{"ht_mask[bb]?"}
    
    FillZero["并行初始化:<br/>num_warmup_chunks[bb, :] = 0"]
    
    CalcBounds["计算序列边界:<br/>seq_start = cu_seqlens[bb]<br/>seq_end = cu_seqlens[bb+1]"]
    
    CalcIters["num_iters = (seq_end - seq_start) // chunk_size"]
    
    InitFragments["初始化寄存器片段:<br/>g_cumsum[:] = 0<br/>n_fragment[:] = num_iters<br/>f_fragment[:] = True"]
    
    LoopStart["循环 i_s = 0 to num_iters-1"]
    
    ReadG["并行读取g值:<br/>g_fragment[h] = <br/>g[0, seq_end - i_s*chunk_size - 1, h]"]
    
    Accumulate["并行累积:<br/>g_cumsum[h] += g_fragment[h]"]
    
    CheckThreshold["并行检查:<br/>if g_cumsum[h] < threshold<br/> and n_fragment[h] == num_iters:"]
    
    Record["记录位置:<br/>n_fragment[h] = i_s + 1<br/>f_fragment[h] = False"]
    
    LoopEnd[结束循环]
    
    WriteBack["写回结果:<br/>num_warmup_chunks[bb, :] = n_fragment[:]<br/>fallback_mask[bb, :] = f_fragment[:]"]
    
    End([结束])
    
    Start --> CheckMask
    CheckMask -->|True| FillZero
    CheckMask -->|False| CalcBounds
    CalcBounds --> CalcIters
    CalcIters --> InitFragments
    InitFragments --> LoopStart
    LoopStart --> ReadG
    ReadG --> Accumulate
    Accumulate --> CheckThreshold
    CheckThreshold -->|满足条件| Record
    CheckThreshold -->|不满足| Skip
    Record --> Skip[跳过]
    Skip --> LoopEnd
    LoopEnd -->|继续下一轮| LoopStart
    LoopEnd -->|所有轮次完成| WriteBack
    FillZero --> WriteBack
    WriteBack --> End
```

# 实现说明
- 由于会根据输入`ht_mask`的取值，走不同分支，所以**多`batch`并行**不方便实现。即使强行实现后，在`ht_mask`大部分为``True`的情况下性能甚至会劣化。
- `hivm.hir.vcmp`在``compare_mode`不是`eq`的情况下，如果数据类型不是`float`类型，会降级成标量循环处理。为了避免这个场景产生的标量循环，通过将`i32`的变量`cast`成`f32`再进行`cmp`来实现将标量循环转为向量操作。
- 由于`n_fragment[i_h] == num_iters` 这一条件，使得**只有第一次**满足累积和小于阈值时，才会被记录。之后该`head` 不再更新，因此最终 `n_fragment`和`f_fragment` 保存的是**从末尾起第一个满足条件的块的索引**。如果直接该段逻辑优化成`vselect`向量化处理，会导致后续的`head`会继续更新，从而导致输出结果不对。因此在向量化之后额外做了输出的修正(`L78~L84`)。