### PR TITLE
Fix A5 gather codegen for tensor regions

### DIFF
--- a/examples/tencent/adc_prefilter_simd_gather.py
+++ b/examples/tencent/adc_prefilter_simd_gather.py
@@ -1,0 +1,172 @@
+"""ADC distance kernel using UB-resident LUT and vector gather for NPUIR.
+
+Input layout:
+  LUT:     [S, K] float32
+  codes:   [N, S] int32
+  out:     [N] float32
+
+This variant is the NPU counterpart of the CUDA-style ADC kernel:
+  1. copy the whole LUT to UB once per physical core;
+  2. copy [block_M, S_TILE] codes tiles to UB and transpose them to
+     [S_TILE, block_M];
+  3. gather each LUT row from UB with T.gather/T.npuir_gather;
+  4. accumulate the gathered row values with SIMD vector add.
+"""
+
+import argparse
+import os
+
+os.environ.setdefault("TILELANG_ASCEND_MODE", "Developer")
+os.environ.setdefault("TILELANG_ENABLE_SIMT", "0")
+
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+
+def env_int(name, default):
+    value = os.environ.get(name)
+    return default if value is None else int(value)
+
+
+@tilelang.jit(out_idx=[-1], target="npuir")
+def adc_distance_ub_gather_kernel(block_M, num_subspaces=64,
+                                  codebook_size=256, dtype="float32",
+                                  code_dtype="int32", num_kernels=56,
+                                  subspace_tile=16):
+    if code_dtype != "int32":
+        raise ValueError("T.gather on NPUIR currently expects int32 indices")
+    if subspace_tile <= 0:
+        raise ValueError("subspace_tile must be positive")
+    if num_subspaces % subspace_tile != 0:
+        raise ValueError("num_subspaces must be divisible by subspace_tile")
+
+    N = T.symbolic("N")
+    num_logic_kernels = T.ceildiv(N, block_M)
+    num_subspace_tiles = num_subspaces // subspace_tile
+
+    @T.prim_func
+    def adc_func(
+        LUT: T.Tensor((num_subspaces, codebook_size), dtype),
+        codes: T.Tensor((N, num_subspaces), code_dtype),
+        out: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(num_kernels, is_npu=True) as (kernel_id, _):
+            LUT_UB = T.alloc_ub((num_subspaces, codebook_size), dtype)
+            CODES_TILE_UB = T.alloc_ub((block_M, subspace_tile), code_dtype)
+            CODES_UB = T.alloc_ub((subspace_tile, block_M), code_dtype)
+            LUT_ROW_UB = T.alloc_ub((1, block_M), dtype)
+            acc = T.alloc_ub((1, block_M), dtype)
+            out_ub = T.alloc_ub((1, block_M), dtype)
+
+            value_zero = 0
+            T.copy(LUT, LUT_UB) #copy进来后gather
+
+            for task_id in T.serial(T.ceildiv(num_logic_kernels, num_kernels)):
+                logic_kernel_id = task_id * num_kernels
+                logic_kernel_id = logic_kernel_id + kernel_id
+                if logic_kernel_id < num_logic_kernels:
+                    start = logic_kernel_id * block_M
+                    valid = T.min(block_M, N - start)
+
+                    T.vbrc(value_zero, CODES_TILE_UB)
+                    T.vbrc(value_zero, acc)
+
+                    for sg in T.serial(num_subspace_tiles):
+                        # 分块
+                        s_base = sg * subspace_tile
+                        T.copy(
+                            codes[start:start + valid,
+                                  s_base:s_base + subspace_tile],
+                            CODES_TILE_UB[0:valid, 0:subspace_tile],
+                        )
+                        T.transpose(CODES_TILE_UB, CODES_UB, [1, 0])
+
+                        # gather
+                        for ss in T.serial(subspace_tile):
+                            s = s_base + ss
+                            T.gather(
+                                LUT_UB[s:s + 1, 0:codebook_size],
+                                LUT_ROW_UB,
+                                CODES_UB[ss:ss + 1, 0:block_M],
+                            )
+                            T.vadd(acc, LUT_ROW_UB, acc)
+
+                    T.vsqrt(acc, out_ub)
+                    T.copy(out_ub[0, 0:valid], out[start:start + valid])
+
+    return adc_func
+
+
+def make_adc_kernel(block_M=256, num_subspaces=64,
+                    codebook_size=256, num_kernels=56, subspace_tile=16):
+    return adc_distance_ub_gather_kernel(
+        block_M,
+        num_subspaces=num_subspaces,
+        codebook_size=codebook_size,
+        num_kernels=num_kernels,
+        subspace_tile=subspace_tile,
+    )
+
+
+def main(n, block_M, num_subspaces, codebook_size, num_kernels, subspace_tile):
+    if n <= 0 or block_M <= 0:
+        raise ValueError("n and block_M must be positive")
+    if num_kernels <= 0:
+        raise ValueError("num_kernels must be positive")
+    if subspace_tile <= 0:
+        raise ValueError("subspace_tile must be positive")
+    if num_subspaces % subspace_tile != 0:
+        raise ValueError("num_subspaces must be divisible by subspace_tile")
+
+    torch.manual_seed(42)
+    # torch.npu.set_device(0)
+
+    lut_cpu = torch.rand(
+        num_subspaces, codebook_size, dtype=torch.float32)
+    codes_cpu = torch.randint(
+        0, codebook_size, (n, num_subspaces), dtype=torch.int32)
+    assert codes_cpu.shape == (n, num_subspaces)
+    sub_idx = torch.arange(num_subspaces, dtype=torch.long).unsqueeze(0)
+    partial = lut_cpu[sub_idx, codes_cpu.long()]
+    ref = torch.sqrt(partial.sum(dim=-1))
+
+    lut = lut_cpu.to("npu")
+    codes = codes_cpu.to("npu")
+
+    print("block_M",block_M)
+    kernel = make_adc_kernel(
+        block_M,
+        num_subspaces=num_subspaces,
+        codebook_size=codebook_size,
+        num_kernels=num_kernels,
+        subspace_tile=subspace_tile,
+    )
+    result = kernel(lut, codes)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(result.cpu(), ref, rtol=1e-3, atol=1e-3)
+    print(
+        f"PASS n={n} block_M={block_M} num_kernels={num_kernels} "
+        f"subspace_tile={subspace_tile}"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n", type=int, default=env_int("TILELANG_ADC_N", 1209631))
+    parser.add_argument("--block-m", type=int,
+                        default=env_int("TILELANG_ADC_BLOCK_M", 832))
+    parser.add_argument("--num-subspaces", type=int,
+                        default=env_int("TILELANG_ADC_S", 64))
+    parser.add_argument("--codebook-size", type=int,
+                        default=env_int("TILELANG_ADC_K", 256))
+    parser.add_argument("--num-kernels", type=int,
+                        default=env_int("TILELANG_ADC_NUM_KERNELS", 56))
+    parser.add_argument("--subspace-tile", type=int,
+                        default=env_int("TILELANG_ADC_S_TILE", 8))
+    args = parser.parse_args()
+    main(args.n, args.block_m, args.num_subspaces, args.codebook_size,
+         args.num_kernels, args.subspace_tile)

--- a/examples/tencent/cdist.py
+++ b/examples/tencent/cdist.py
@@ -1,0 +1,163 @@
+import argparse
+import os
+
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def cdist_squared_pytorch(x1, x2):
+    diff = x1.to(torch.float32).unsqueeze(1) - x2.to(torch.float32).unsqueeze(0)
+    return torch.sum(diff * diff, dim=-1).squeeze(0)
+
+
+def ref_program(A, B):
+    return cdist_squared_pytorch(A, B)
+
+
+def supply_prog(args):
+    dtype = torch.bfloat16
+    # NPU
+    query_hidden_states = torch.ones(1, 256, dtype=dtype, device="npu")
+    c_embs = torch.ones(2000000, 256, dtype=dtype, device="npu")
+    return [query_hidden_states, c_embs]
+
+
+def manual_check_prog(actual, expected):
+    actual_tensor = actual[0] if isinstance(actual, (list, tuple)) else actual
+    expected_tensor = expected[0] if isinstance(expected, (list, tuple)) else expected
+    return torch.allclose(actual_tensor, expected_tensor, rtol=1e-2, atol=1e-2)
+
+
+def get_configs():
+    return [
+        {"block_M": block_M, "block_N": block_N}
+        for block_M in [16, 32, 64]
+        for block_N in [128, 256]
+    ]
+
+
+# NPU
+@tilelang.jit(out_idx=[-1], target="npuir")
+def distance(
+    M,
+    N,
+    block_N=256,
+    block_M=32,
+    dtype="bfloat16",
+    accum_dtype="float32",
+    num_kernels=56,
+):
+    """Developer 模式 NPU kernel：计算 query 与 codebook 每一行的平方欧氏距离。
+
+    输入:
+      A: [1, N]，单条 query 向量
+      B: [M, N]，M 条待比较向量
+    输出:
+      C: [M]，C[m] = sum_j((A[0, j] - B[m, j]) ** 2)
+    """
+
+    num_logic_kernels = T.ceildiv(M, block_M)
+
+    @T.prim_func
+    def dist(
+        A: T.Tensor((1, N), dtype),
+        B: T.Tensor((M, N), dtype),
+        C: T.Tensor((M,), accum_dtype),
+    ):
+        with T.Kernel(num_kernels, is_npu=True) as (kernel_id, _):
+            A_shared = T.alloc_shared((1, block_N), dtype)
+            B_shared = T.alloc_shared((block_M, block_N), dtype)
+            diff = T.alloc_shared((block_M, block_N), dtype)
+            diff_sq = T.alloc_shared((block_M, block_N), dtype)
+            partial_sum = T.alloc_shared((block_M, 1), dtype)
+            total_sum = T.alloc_shared((block_M, 1), dtype)
+            total_sum_f32 = T.alloc_shared((block_M, 1), accum_dtype)
+
+            for task_id in T.serial(T.ceildiv(num_logic_kernels, num_kernels)):
+                logic_kernel_id = task_id * num_kernels
+                logic_kernel_id = logic_kernel_id + kernel_id
+                if logic_kernel_id < num_logic_kernels:
+                    row_offset = logic_kernel_id * block_M
+                    real_m = T.min(block_M, M - row_offset)
+
+                    T.clear(total_sum)
+
+                    for n_tile in T.serial(T.ceildiv(N, block_N)):
+                        col_offset = n_tile * block_N
+                        real_n = T.min(block_N, N - col_offset)
+
+                        T.clear(A_shared)
+                        T.clear(B_shared)
+
+                        T.copy(
+                            A[0:1, col_offset : col_offset + real_n],
+                            A_shared[0:1, 0:real_n],
+                        )
+                        T.copy(
+                            B[
+                                row_offset : row_offset + real_m,
+                                col_offset : col_offset + real_n,
+                            ],
+                            B_shared[0:real_m, 0:real_n],
+                        )
+
+
+                        T.vsub(A_shared, B_shared, diff)
+                        T.vmul(diff, diff, diff_sq)
+
+                        T.reduce_sum(diff_sq, partial_sum, dim=1)
+                        T.vadd(total_sum, partial_sum, total_sum)
+
+                    T.vcast(total_sum, total_sum_f32, round_mode="rint")
+                    T.copy(
+                        total_sum_f32[0:real_m, 0],
+                        C[row_offset : row_offset + real_m],
+                    )
+
+    return dist
+
+
+def run_test(M=1024, N=256, block_M=32, block_N=256, dtype="bfloat16"):
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+    torch.npu.set_device(0)
+    tilelang.cache.clear_cache()
+
+    torch_dtype = getattr(torch, dtype)
+    query = torch.randn((1, N), dtype=torch_dtype, device="npu")
+    codebook = torch.randn((M, N), dtype=torch_dtype, device="npu")
+
+    kernel = distance(
+        M,
+        N,
+        block_N=block_N,
+        block_M=block_M,
+        dtype=dtype,
+        accum_dtype="float32",
+    )
+    output = kernel(query, codebook)
+    expected = ref_program(query, codebook)
+
+    print("NPU output:")
+    print(output)
+    print("Reference:")
+    print(expected)
+    print(output.shape)
+    torch.testing.assert_close(output.cpu(), expected.cpu(), rtol=1e-2, atol=1e-2)
+    print("\033[92mAll check passed!\033[0m")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="CDist squared L2 NPU Developer kernel")
+    parser.add_argument("--M", type=int, default=1986514)
+    parser.add_argument("--N", type=int, default=256)
+    parser.add_argument("--block_M", type=int, default=128)
+    parser.add_argument("--block_N", type=int, default=256)
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bfloat16",
+        choices=["float16", "float32", "bfloat16"],
+    )
+    args = parser.parse_args()
+    run_test(args.M, args.N, args.block_M, args.block_N, args.dtype)

--- a/src/target/codegen_npuir_dev_a5.cc
+++ b/src/target/codegen_npuir_dev_a5.cc
@@ -2881,14 +2881,51 @@ void CodeGenTileLangNPUIRDEVA5::VAtomicAddCodegen(const CallNode *op) {
 
 void CodeGenTileLangNPUIRDEVA5::VgatherCodegen(const CallNode *op) {
   tvm::tl::NpuirGather npuirop(op->args, this->vmap);
-  Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
-  Value dst = GenSubviewFromRegion(npuirop.dst, npuirop.dst_range);
-  Value indices = GenSubviewFromRegion(npuirop.indices, npuirop.indices_range);
+
+  auto genRegionValue = [&](const Buffer &buffer,
+                            const Array<Range> &range) -> mlir::Value {
+    mlir::Value base = GetVarValue(buffer);
+    ICHECK(base) << "tl.npuir_gather: missing MLIR value for buffer "
+                 << buffer->name;
+    if (base.getType().isa<mlir::MemRefType>()) {
+      return GenSubviewFromRegion(buffer, range);
+    }
+    if (base.getType().isa<mlir::RankedTensorType>()) {
+      return GenExtractSliceFromRegion(buffer, range);
+    }
+    ICHECK(false) << "tl.npuir_gather: expected tensor or memref buffer";
+    return mlir::Value();
+  };
+
+  Value src = genRegionValue(npuirop.src, npuirop.src_range);
+  Value indices = genRegionValue(npuirop.indices, npuirop.indices_range);
+
+  mlir::Value dstBase = GetVarValue(npuirop.dst);
+  ICHECK(dstBase) << "tl.npuir_gather: missing MLIR value for dst buffer "
+                  << npuirop.dst->name;
+  Value dst = genRegionValue(npuirop.dst, npuirop.dst_range);
+  bool dstIsTensor = dstBase.getType().isa<mlir::RankedTensorType>();
+  bool dstIsMemref = dstBase.getType().isa<mlir::MemRefType>();
+  ICHECK(dstIsTensor || dstIsMemref)
+      << "tl.npuir_gather: expected tensor or memref dst";
+
+  Value gatherInit = dst;
+  bool needInsertSlice = false;
+  if (dstIsTensor) {
+    gatherInit = NeedGenInsertSlice(npuirop.dst, npuirop.dst_range, dst);
+    needInsertSlice = (gatherInit != dstBase);
+  }
 
   auto newGatherOp = builder.create<hfusion::GatherOp>(
-      builder.getUnknownLoc(), src, indices, dst,
+      builder.getUnknownLoc(), src, indices, gatherInit,
       src.getType().cast<ShapedType>().getRank() - 1);
-  SetVarValue(npuirop.dst, newGatherOp->getResult(0));
+  if (newGatherOp->getNumResults() > 0) {
+    mlir::Value result = newGatherOp->getResult(0);
+    if (dstIsTensor && needInsertSlice) {
+      result = ReshapeCastAndInsertSlice(result, dstBase, npuirop.dst_range);
+    }
+    SetVarValue(npuirop.dst, result);
+  }
 }
 
 void CodeGenTileLangNPUIRDEVA5::EnsureTritonIndirectLoadDecl(


### PR DESCRIPTION
Teach the A5 NPUIR gather codegen to choose tensor extract-slices or memref subviews based on the current buffer value, and to insert tensor gather results back into partial destination regions.

Add the Tencent ADC SIMD gather example that exercises the UB-resident LUT gather path with int32 codes.