### PR TITLE
[AscendNPU-IR]Support Composite TIR Expressions in Dynamic Shape Dimensions

### DIFF
--- a/examples/flash_qla/tilelang_get_warmup_chunks.py
+++ b/examples/flash_qla/tilelang_get_warmup_chunks.py
@@ -1,0 +1,257 @@
+import os
+
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+DTYPE_TO_STR = {
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.int16: "int16",
+    torch.int8: "int8",
+    torch.uint8: "uint8",
+    torch.bool: "bool",
+}
+
+
+@tilelang.jit(target="npuir")
+def tilelang_get_warmup_chunks(
+    num_heads,
+    chunk_size,
+    threshold,
+    accum_dtype,
+    g_dtype,
+    mask_dtype,
+    seqlen_dtype,
+    reverse,
+):
+    batch_size = T.dynamic("batch_size")
+    num_tokens = T.dynamic("num_tokens")
+    num_cu_seqlens = T.dynamic("num_cu_seqlens")
+
+    @T.prim_func
+    def tilelang_get_warmup_chunks_kernel(
+        g: T.Tensor([1, num_tokens, num_heads], dtype=g_dtype),
+        ht_mask: T.Tensor([batch_size], dtype=mask_dtype),
+        cu_seqlens: T.Tensor([num_cu_seqlens], dtype=seqlen_dtype),
+        num_warmup_chunks: T.Tensor([batch_size, num_heads], dtype=seqlen_dtype),
+        fallback_mask: T.Tensor([batch_size, num_heads], dtype=mask_dtype),
+    ):
+        with T.Kernel(batch_size, is_npu=True) as (bb, _):
+            ht_mask_shared = T.alloc_shared((1,), mask_dtype)
+            T.copy(ht_mask[bb], ht_mask_shared)
+            n_fragment = T.alloc_fragment((num_heads,), seqlen_dtype)
+            f_fragment = T.alloc_fragment((num_heads,), "float16")
+
+            if ht_mask_shared[0] == 0:
+                g_shared = T.alloc_shared((num_heads,), g_dtype)
+                g_cumsum = T.alloc_fragment((num_heads,), accum_dtype)
+
+                sentinel = T.alloc_fragment((num_heads,), seqlen_dtype)
+                cmp_lt = T.alloc_fragment((num_heads,), "bool")
+                cmp_eq = T.alloc_fragment((num_heads,), "bool")
+                cond = T.alloc_fragment((num_heads,), "bool")
+                tmp1 = T.alloc_fragment((num_heads,), seqlen_dtype)
+
+                f_cmp = T.alloc_fragment((num_heads,), "bool")
+                zero_full = T.alloc_fragment((num_heads,), "float16")
+                one_full = T.alloc_fragment((num_heads,), "float16")
+
+                sentinel_f32 = T.alloc_fragment((num_heads,), "float32")
+                n_fragment_f32 = T.alloc_fragment((num_heads,), "float32")
+
+                T.clear(g_cumsum)
+
+                num_iters = (cu_seqlens[bb + 1] - cu_seqlens[bb]) // chunk_size
+                sentinel_val = num_iters + 1
+                T.vbrc(sentinel_val, sentinel)
+                T.vbrc(sentinel_val, n_fragment)
+                T.vbrc(T.float32(sentinel_val), sentinel_f32)
+                T.vbrc(T.int32(0), tmp1)
+
+                start_idx = cu_seqlens[bb] + chunk_size - 1
+                end_idx = cu_seqlens[bb + 1] - 1
+                for i_s in T.serial(num_iters):
+                    if reverse:
+                        row_idx = start_idx + i_s * chunk_size
+                        T.copy(g[0, row_idx, 0:num_heads], g_shared)
+                    else:
+                        row_idx = end_idx - i_s * chunk_size
+                        T.copy(g[0, row_idx, 0:num_heads], g_shared)
+
+                    if g_dtype != accum_dtype:
+                        g_shared_cast = T.alloc_shared((num_heads,), accum_dtype)
+                        T.vcast(g_shared, g_shared_cast)
+                        T.vadd(g_cumsum, g_shared_cast, g_cumsum)
+                    else:
+                        T.vadd(g_cumsum, g_shared, g_cumsum)
+
+                    T.vcmp(g_cumsum, T.float32(threshold), cmp_lt, "lt")
+                    T.vcmp(n_fragment, sentinel, cmp_eq, "eq")
+                    T.vand(cmp_lt, cmp_eq, cond)
+                    T.vadd(tmp1, 1, tmp1)
+                    T.vselect(cond, tmp1, n_fragment, n_fragment)
+
+                T.vbrc(T.float16(0), zero_full)
+                T.vbrc(T.float16(1), one_full)
+                T.vcast(n_fragment, n_fragment_f32)
+                T.vcmp(n_fragment_f32, sentinel_f32, f_cmp, "lt")
+                T.vselect(f_cmp, zero_full, one_full, f_fragment)
+
+                T.vbrc(num_iters, tmp1)
+                T.vselect(f_cmp, n_fragment, tmp1, n_fragment)
+
+                T.copy(n_fragment, num_warmup_chunks[bb, 0])
+                T.copy(f_fragment, fallback_mask[bb, 0])
+            else:
+                T.vbrc(T.int32(0), n_fragment)
+                T.copy(n_fragment, num_warmup_chunks[bb, 0])
+
+    return tilelang_get_warmup_chunks_kernel
+
+
+def get_warmup_chunks(
+    g: torch.Tensor,  # [1, num_total_tokens, num_v_heads]
+    cu_seqlens: torch.Tensor,  # [cp_real_batch_size + 1]
+    ht_mask: torch.Tensor,  # [cp_real_batch_size]
+    chunk_size: int = 64,
+    threshold: float = -10.0,
+    reverse: bool = False,
+):
+    batch_size, num_tokens, num_heads = g.shape
+    real_batch_size = ht_mask.shape[0]
+    assert cu_seqlens.shape[0] == real_batch_size + 1
+    assert batch_size == 1
+    assert chunk_size == 64
+
+    tilelang_get_warmup_chunks_kernel = tilelang_get_warmup_chunks(
+        num_heads=num_heads,
+        chunk_size=chunk_size,
+        threshold=threshold,
+        accum_dtype="float32",
+        g_dtype=DTYPE_TO_STR[g.dtype],
+        mask_dtype=DTYPE_TO_STR[ht_mask.dtype],
+        seqlen_dtype=DTYPE_TO_STR[cu_seqlens.dtype],
+        reverse=reverse,
+    )
+    num_warmup_chunks = torch.empty(
+        [real_batch_size, num_heads], dtype=cu_seqlens.dtype, device=cu_seqlens.device
+    )
+    fallback_mask = torch.empty(
+        [real_batch_size, num_heads], dtype=ht_mask.dtype, device=cu_seqlens.device
+    )
+    tilelang_get_warmup_chunks_kernel(
+        g, ht_mask, cu_seqlens, num_warmup_chunks, fallback_mask
+    )
+
+    return num_warmup_chunks, fallback_mask
+
+
+def get_warmup_chunks_torch_ref(
+    g, ht_mask, cu_seqlens, num_heads, chunk_size, threshold, reverse
+):
+    batch_size = ht_mask.shape[0]
+    num_warmup_chunks = torch.zeros(
+        (batch_size, num_heads), dtype=cu_seqlens.dtype, device="cpu"
+    )
+    fallback_mask = torch.zeros(
+        (batch_size, num_heads), dtype=ht_mask.dtype, device="cpu"
+    )
+
+    g_cpu = g.cpu()
+    ht_mask_cpu = ht_mask.cpu()
+    cu_seqlens_cpu = cu_seqlens.cpu()
+
+    n_iters_list = [0] * batch_size
+    for b in range(batch_size):
+        if ht_mask_cpu[b] != 0:
+            num_warmup_chunks[b, :] = 0
+            fallback_mask[b, :] = 0
+        else:
+            seq_start = cu_seqlens_cpu[b].item()
+            seq_end = cu_seqlens_cpu[b + 1].item()
+            n_iters = (seq_end - seq_start) // chunk_size
+            n_iters_list[b] = n_iters
+
+            g_cumsum = torch.zeros(num_heads, dtype=torch.float32)
+            n_frag = torch.full((num_heads,), n_iters, dtype=cu_seqlens.dtype)
+            f_frag = torch.ones(num_heads, dtype=ht_mask.dtype)
+
+            for s in range(n_iters):
+                idx = seq_end - s * chunk_size - 1
+                if reverse:
+                    idx = seq_start + (s + 1) * chunk_size - 1
+
+                g_val = g_cpu[0, idx, :]
+                g_cumsum += g_val
+                for h in range(num_heads):
+                    if g_cumsum[h] < threshold and n_frag[h] == n_iters:
+                        n_frag[h] = s + 1
+                        f_frag[h] = 0
+
+            num_warmup_chunks[b, :] = n_frag
+            fallback_mask[b, :] = f_frag
+    print(n_iters_list)
+    return num_warmup_chunks, fallback_mask
+
+
+def test_get_warmup_chunks():
+    os.environ["TILELANG_ASCEND_MODE"] = "Developer"
+    tilelang.cache.clear_cache()
+
+    batch_size = 48
+    num_tokens = 1024 * 128
+    num_heads = 256
+    chunk_size = 64
+    threshold = -10.0
+
+    torch.manual_seed(42)
+
+    g = (torch.randn((1, num_tokens, num_heads), dtype=torch.float16) * 0.8).npu()
+    ht_mask = torch.randint(0, 2, (batch_size,), dtype=torch.int8).npu()
+
+    num_chunks = num_tokens // chunk_size
+    rand_boundaries = torch.sort(torch.randint(1, num_chunks, (batch_size - 1,)))[0]
+    cu_seqlens = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32),
+            (rand_boundaries * chunk_size).to(torch.int32),
+            torch.tensor([num_tokens], dtype=torch.int32),
+        ]
+    ).npu()
+
+    reverse = True
+    ref_num_warmup, ref_fallback = get_warmup_chunks_torch_ref(
+        g, ht_mask, cu_seqlens, num_heads, chunk_size, threshold, reverse
+    )
+
+    num_warmup_chunks_out, fallback_mask_out = get_warmup_chunks(
+        g, cu_seqlens, ht_mask, chunk_size, threshold, reverse
+    )
+
+    torch.testing.assert_close(
+        num_warmup_chunks_out.cpu(), ref_num_warmup, rtol=0, atol=0
+    )
+    print("num_warmup_chunks check passed!")
+
+    torch.testing.assert_close(
+        fallback_mask_out.cpu().to(ref_fallback.dtype), ref_fallback, rtol=0, atol=0
+    )
+    print("fallback_mask check passed!")
+
+    for _ in range(10):
+        num_warmup_chunks_out, fallback_mask_out = get_warmup_chunks(
+            g, cu_seqlens, ht_mask, chunk_size, threshold
+        )
+
+    print("\033[92mAll check passed!\033[0m")
+
+
+if __name__ == "__main__":
+    test_get_warmup_chunks()

--- a/testing/python/jit/test_composite_dynamic_shape.py
+++ b/testing/python/jit/test_composite_dynamic_shape.py
@@ -1,0 +1,150 @@
+"""Unit test for composite dynamic shape support in _process_dynamic_symbolic."""
+import tilelang.language as T
+from tvm import tir
+from tilelang.jit.jit_npu import (
+    _collect_tir_vars,
+    _detect_affine,
+    _eval_tir_expr,
+    _process_dynamic_symbolic,
+    _symbolic_var_promoter_pass,
+)
+
+
+def test_helpers():
+    batch_size = tir.Var("batch_size", "int32")
+
+    # _collect_tir_vars
+    vars_found = _collect_tir_vars(batch_size + 1)
+    assert len(vars_found) == 1 and vars_found[0].name == "batch_size"
+
+    vars_found = _collect_tir_vars(batch_size * 2 + 3)
+    assert len(vars_found) == 1 and vars_found[0].name == "batch_size"
+
+    # _detect_affine
+    assert _detect_affine(batch_size + 1, batch_size) == (1, 1)
+    assert _detect_affine(batch_size * 2 + 3, batch_size) == (2, 3)
+    assert _detect_affine(batch_size, batch_size) == (1, 0)
+    assert _detect_affine(tir.IntImm("int32", 42), batch_size) == (0, 42)
+    assert _detect_affine(batch_size - 5, batch_size) == (1, -5)
+
+    # _eval_tir_expr
+    dynamic_val = {"batch_size": 7}
+    assert _eval_tir_expr(batch_size + 1, dynamic_val) == 8
+    assert _eval_tir_expr(batch_size * 2, dynamic_val) == 14
+    assert _eval_tir_expr(batch_size * 2 + 3, dynamic_val) == 17
+
+    print("[PASS] test_helpers")
+
+
+def test_process_dynamic_symbolic_composite():
+    """Test that _process_dynamic_symbolic detects vars inside composite expressions."""
+    raw_batch_size = T.dynamic("raw_batch_size")
+    cp_batch_size = T.dynamic("cp_batch_size")
+
+    @T.prim_func
+    def kernel(
+        ht_buffer: T.Tensor([cp_batch_size, 2, 128, 128], "float16"),
+        seq_map_r2c: T.Tensor([raw_batch_size + 1], "int32"),
+        cp_h0: T.Tensor([cp_batch_size, 2, 128, 128], "float16"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            seq_map_r2c[0] = seq_map_r2c[0]
+
+    dyn_map = _process_dynamic_symbolic(kernel)
+
+    # raw_batch_size should be registered with affine binding
+    raw_entries = [(str(k), v) for k, v in dyn_map.items() if str(k) == "raw_batch_size"]
+    assert len(raw_entries) == 1, f"Expected 1 entry for raw_batch_size, got {len(raw_entries)}"
+    _, raw_pos = raw_entries[0]
+    assert len(raw_pos) == 4, f"Expected affine binding (4-tuple), got {len(raw_pos)}-tuple"
+    assert raw_pos[2] == 1 and raw_pos[3] == 1, f"Expected a=1, b=1, got a={raw_pos[2]}, b={raw_pos[3]}"
+
+    # cp_batch_size should be registered with direct binding
+    cp_entries = [(str(k), v) for k, v in dyn_map.items() if str(k) == "cp_batch_size"]
+    assert len(cp_entries) == 1
+    _, cp_pos = cp_entries[0]
+    assert len(cp_pos) == 2, f"Expected direct binding (2-tuple), got {len(cp_pos)}-tuple"
+
+    print("[PASS] test_process_dynamic_symbolic_composite")
+
+
+def test_process_dynamic_symbolic_prefer_direct():
+    """When a var has both a direct and a composite binding, prefer direct."""
+    batch_size = T.dynamic("batch_size")
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor([batch_size], "float16"),
+        B: T.Tensor([batch_size + 1], "int32"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            A[0] = A[0]
+
+    dyn_map = _process_dynamic_symbolic(kernel)
+
+    bs_entries = [(str(k), v) for k, v in dyn_map.items() if str(k) == "batch_size"]
+    assert len(bs_entries) == 1
+    _, pos = bs_entries[0]
+    assert len(pos) == 2, f"Expected direct binding preferred, got {len(pos)}-tuple"
+
+    print("[PASS] test_process_dynamic_symbolic_prefer_direct")
+
+
+def test_symbolic_var_promoter_with_composite():
+    """Test that _symbolic_var_promoter_pass correctly promotes vars from composite shapes."""
+    raw_batch_size = T.dynamic("raw_batch_size")
+
+    @T.prim_func
+    def kernel(
+        seq_map_r2c: T.Tensor([raw_batch_size + 1], "int32"),
+        out: T.Tensor([raw_batch_size + 1], "int32"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            seq_map_r2c[0] = seq_map_r2c[0]
+
+    new_func, new_map = _symbolic_var_promoter_pass(kernel)
+    assert len(new_func.params) == len(kernel.params) + 1, "Should promote 1 symbolic var"
+    assert any(str(k) == "raw_batch_size" for k in new_map.keys())
+
+    print("[PASS] test_symbolic_var_promoter_with_composite")
+
+
+def test_runtime_resolution():
+    """Simulate runtime resolution: given actual_dim, compute var value via affine inverse."""
+    raw_batch_size = T.dynamic("raw_batch_size")
+
+    @T.prim_func
+    def kernel(
+        seq_map_r2c: T.Tensor([raw_batch_size + 1], "int32"),
+        out: T.Tensor([raw_batch_size + 1], "int32"),
+    ):
+        with T.Kernel(1, is_npu=True) as (cid, _):
+            seq_map_r2c[0] = seq_map_r2c[0]
+
+    dyn_map = _process_dynamic_symbolic(kernel)
+
+    # Simulate _calcu_grid resolution
+    actual_dim = 9  # the actual seq_map_r2c.shape[0]
+    for key, pos in dyn_map.items():
+        if str(key) == "raw_batch_size":
+            assert len(pos) == 4
+            a, b = pos[2], pos[3]
+            resolved_value = (actual_dim - b) // a
+            assert resolved_value == 8, f"Expected raw_batch_size=8, got {resolved_value}"
+
+    # Simulate output shape evaluation
+    dynamic_val = {"raw_batch_size": 8}
+    output_shape_expr = raw_batch_size + 1
+    output_dim = _eval_tir_expr(output_shape_expr, dynamic_val)
+    assert output_dim == 9, f"Expected output dim=9, got {output_dim}"
+
+    print("[PASS] test_runtime_resolution")
+
+
+if __name__ == "__main__":
+    test_helpers()
+    test_process_dynamic_symbolic_composite()
+    test_process_dynamic_symbolic_prefer_direct()
+    test_symbolic_var_promoter_with_composite()
+    test_runtime_resolution()
+    print("\nAll tests passed!")

--- a/testing/python/jit/test_regression_dynamic_shape.py
+++ b/testing/python/jit/test_regression_dynamic_shape.py
@@ -1,0 +1,68 @@
+"""Regression test: verify existing bare-var dynamic shapes still work after the fix."""
+import sys
+sys.path.insert(0, "testing/npuir")
+from testcommon import gen_tensor, assert_close
+import tilelang
+import tilelang.language as T
+import torch
+import torch_npu  # noqa: F401
+
+
+def test_jit_bare_var_dynamic():
+    """Test the @tilelang.jit decorator path with bare-var dynamic shapes.
+
+    This is the pattern used by all existing npuir dynamic-shape kernels
+    (e.g. test_2d_grid_gemm_dyn_exp.py, test_copy_shape_dynamic.py).
+    """
+
+    @tilelang.jit(target="npuir")
+    def make_kernel(dtype: str):
+        M = T.symbolic("M")
+
+        @T.prim_func
+        def kernel(
+            A: T.Tensor((M,), dtype),
+            B: T.Tensor((M,), dtype),
+        ):
+            with T.Kernel(M, is_npu=True) as (cid, _):
+                A_BUF = T.alloc_ub((1,), dtype)
+                T.copy(A[cid : cid + 1], A_BUF[0:1])
+                T.copy(A_BUF[0:1], B[cid : cid + 1])
+
+        return kernel
+
+    kernel = make_kernel(dtype="float16")
+    v1 = gen_tensor((8,), "float16", kind="randn")
+    v2 = gen_tensor((8,), "float16", kind="zeros")
+    kernel(v1, v2)
+    assert_close(v2.cpu(), v1.cpu(), dtype="float16", rtol=1e-2, atol=1e-2)
+    print("[PASS] test_jit_bare_var_dynamic")
+
+
+def test_compile_bare_var_dynamic():
+    """Test tilelang.compile path with bare-var dynamic shapes."""
+    M = T.symbolic("M")
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((M,), "float16"),
+        B: T.Tensor((M,), "float16"),
+        shape_M: T.int32,
+    ):
+        with T.Kernel(M, is_npu=True) as (cid, _):
+            A_BUF = T.alloc_ub((1,), "float16")
+            T.copy(A[cid : cid + 1], A_BUF[0:1])
+            T.copy(A_BUF[0:1], B[cid : cid + 1])
+
+    compiled = tilelang.compile(kernel, target="npuir")
+    v1 = gen_tensor((8,), "float16", kind="randn")
+    v2 = gen_tensor((8,), "float16", kind="zeros")
+    compiled(v1, v2, 8)
+    assert_close(v2.cpu(), v1.cpu(), dtype="float16", rtol=1e-2, atol=1e-2)
+    print("[PASS] test_compile_bare_var_dynamic")
+
+
+if __name__ == "__main__":
+    test_jit_bare_var_dynamic()
+    test_compile_bare_var_dynamic()
+    print("\nAll regression tests passed!")

--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import List, Union, Optional
 import torch
 from tilelang import tvm as tvm
-from tvm.tir import Buffer, IntImm, Var
+from tvm.tir import Buffer, IntImm, Var, PrimExpr
 from tilelang.utils.tensor import map_torch_type
 
 
@@ -17,7 +17,7 @@ class KernelParam:
     Used to describe tensor or scalar parameters in TVM/PyTorch interop.
     """
     dtype: torch.dtype  # PyTorch data type of the parameter
-    shape: List[Union[int, Var]]  # List of dimensions, can be integers or TVM variables
+    shape: List[Union[int, Var, PrimExpr]]  # List of dimensions, can be integers, TVM variables, or composite PrimExpr
 
     @classmethod
     def from_buffer(cls, buffer: Buffer):
@@ -29,19 +29,16 @@ class KernelParam:
             
         Returns:
             KernelParam instance with converted dtype and shape
-            
-        Raises:
-            ValueError: If dimension type is not supported (not IntImm or Var)
         """
         dtype = map_torch_type(buffer.dtype)
         shape = []
         for s in buffer.shape:
             if isinstance(s, IntImm):
                 shape.append(s.value)
-            elif isinstance(s, Var):
+            elif isinstance(s, (Var, PrimExpr)):
                 shape.append(s)
             else:
-                raise ValueError(f"Unsupported dimension type: {type(s)}")
+                shape.append(s)
         return cls(dtype, shape)
 
     @classmethod

--- a/tilelang/jit/jit_npu.py
+++ b/tilelang/jit/jit_npu.py
@@ -110,18 +110,199 @@ def _transform_stmt(stmt, symbolic_var_names):
         return stmt
 
 
-# Collect all variables used in the buffer shape
+def _collect_tir_vars(expr):
+    """Collect all tir.Var nodes from a TIR expression, preserving first-seen order."""
+    vars_found = []
+    seen = set()
+
+    def visit(node):
+        if isinstance(node, tir.Var):
+            key = node.name
+            if key not in seen:
+                seen.add(key)
+                vars_found.append(node)
+
+    tir.stmt_functor.post_order_visit(expr, visit)
+    return vars_found
+
+
+def _detect_affine(expr, var):
+    """Detect if expr is affine in *var*: expr = a * var + b.
+
+    Returns (a, b) as Python ints, or None if not affine in *var*.
+    """
+    if isinstance(expr, tir.Var):
+        if expr.same_as(var) or expr.name == var.name:
+            return (1, 0)
+        return None
+
+    if isinstance(expr, tir.IntImm):
+        return (0, int(expr))
+
+    if isinstance(expr, tir.Add):
+        left = _detect_affine(expr.a, var)
+        right = _detect_affine(expr.b, var)
+        if left is not None and right is not None:
+            return (left[0] + right[0], left[1] + right[1])
+        return None
+
+    if isinstance(expr, tir.Sub):
+        left = _detect_affine(expr.a, var)
+        right = _detect_affine(expr.b, var)
+        if left is not None and right is not None:
+            return (left[0] - right[0], left[1] - right[1])
+        return None
+
+    if isinstance(expr, tir.Mul):
+        left = _detect_affine(expr.a, var)
+        right = _detect_affine(expr.b, var)
+        if left is not None and right is not None:
+            if left[0] == 0:
+                scale = left[1]
+                return (right[0] * scale, right[1] * scale)
+            if right[0] == 0:
+                scale = right[1]
+                return (left[0] * scale, left[1] * scale)
+            return None
+        return None
+
+    if isinstance(expr, tir.FloorDiv):
+        left = _detect_affine(expr.a, var)
+        if left is not None and isinstance(expr.b, tir.IntImm):
+            divisor = int(expr.b)
+            if left[0] == 0:
+                return (0, left[1] // divisor)
+        return None
+
+    return None
+
+
+def _eval_tir_expr(expr, dynamic_val):
+    """Evaluate a TIR PrimExpr at runtime using resolved dynamic values.
+
+    *dynamic_val* maps var-name (str) -> int.
+    """
+    if isinstance(expr, tir.Var):
+        val = dynamic_val.get(str(expr))
+        if val is None:
+            raise ValueError(
+                f"Missing runtime value for symbolic var '{expr}' in shape expression"
+            )
+        return val
+
+    if isinstance(expr, tir.IntImm):
+        return int(expr)
+
+    if isinstance(expr, tir.Add):
+        return _eval_tir_expr(expr.a, dynamic_val) + _eval_tir_expr(
+            expr.b, dynamic_val
+        )
+
+    if isinstance(expr, tir.Sub):
+        return _eval_tir_expr(expr.a, dynamic_val) - _eval_tir_expr(
+            expr.b, dynamic_val
+        )
+
+    if isinstance(expr, tir.Mul):
+        return _eval_tir_expr(expr.a, dynamic_val) * _eval_tir_expr(
+            expr.b, dynamic_val
+        )
+
+    if isinstance(expr, tir.FloorDiv):
+        return _eval_tir_expr(expr.a, dynamic_val) // _eval_tir_expr(
+            expr.b, dynamic_val
+        )
+
+    if isinstance(expr, tir.Div):
+        return _eval_tir_expr(expr.a, dynamic_val) // _eval_tir_expr(
+            expr.b, dynamic_val
+        )
+
+    if isinstance(expr, tir.Mod):
+        return _eval_tir_expr(expr.a, dynamic_val) % _eval_tir_expr(
+            expr.b, dynamic_val
+        )
+
+    if isinstance(expr, tir.Max):
+        return max(
+            _eval_tir_expr(expr.a, dynamic_val), _eval_tir_expr(expr.b, dynamic_val)
+        )
+
+    if isinstance(expr, tir.Min):
+        return min(
+            _eval_tir_expr(expr.a, dynamic_val), _eval_tir_expr(expr.b, dynamic_val)
+        )
+
+    expr_str = str(expr)
+    try:
+        return int(eval(expr_str, {"__builtins__": {}}, dict(dynamic_val)))
+    except Exception as e:
+        raise ValueError(
+            f"Cannot evaluate shape expression '{expr_str}': {e}"
+        ) from e
+
+
+# Collect all variables used in the buffer shape, including vars nested
+# inside composite TIR expressions such as tir.Add(var, 1).
 def _process_dynamic_symbolic(func):
     params = func.params
     buffer_map = func.buffer_map
     dynamic_symbolic_map = {}
-    for i, param in enumerate(params):
+
+    # Phase 1: collect every tir.Var that appears in any buffer shape,
+    # including those nested inside composite expressions (Add, Sub, Mul, ...).
+    all_vars = []
+    seen_var_names = set()
+    for param in params:
         if param not in buffer_map:
             continue
         buffer = buffer_map[param]
-        for j, shape in enumerate(buffer.shape):
-            if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map):
-                dynamic_symbolic_map[shape] = (i, j)
+        for shape in buffer.shape:
+            for v in _collect_tir_vars(shape):
+                if v.name not in seen_var_names:
+                    seen_var_names.add(v.name)
+                    all_vars.append(v)
+
+    # Phase 2: for each var, find the best binding.
+    #   - Preferred: a buffer dim whose shape IS the var (direct binding).
+    #   - Fallback: a buffer dim whose shape is an affine expression in var
+    #     (composite binding with inverse transform).
+    for var in all_vars:
+        # Skip vars that are already explicit parameters (scalar params).
+        if var in params:
+            continue
+
+        # Try direct binding first.
+        for i, param in enumerate(params):
+            if param not in buffer_map:
+                continue
+            buffer = buffer_map[param]
+            for j, shape in enumerate(buffer.shape):
+                if isinstance(shape, tir.Var) and shape.same_as(var):
+                    dynamic_symbolic_map[var] = (i, j)
+                    break
+            if var in dynamic_symbolic_map:
+                break
+
+        if var in dynamic_symbolic_map:
+            continue
+
+        # Fall back to affine binding.
+        for i, param in enumerate(params):
+            if param not in buffer_map:
+                continue
+            buffer = buffer_map[param]
+            for j, shape in enumerate(buffer.shape):
+                if isinstance(shape, tir.Var):
+                    continue
+                affine = _detect_affine(shape, var)
+                if affine is not None and affine[0] != 0:
+                    a, b = affine
+                    dynamic_symbolic_map[var] = (i, j, a, b)
+                    break
+            if var in dynamic_symbolic_map:
+                break
+
     return dynamic_symbolic_map
 
 
@@ -902,14 +1083,21 @@ class JitKernel_NPU:
         dynamic_val = {}
         extra_args = []
         for key, pos in self.symbolic.items():
-            # Ensure that pos is a tuple with two elements.
+            # pos is (buffer_idx, dim_idx) for direct binding,
+            # or (buffer_idx, dim_idx, a, b) for affine binding where
+            # var = (actual_dim - b) // a.
             if isinstance(pos, (tuple, list)) and len(pos) >= 2:
                 tensor_idx, dim_idx = pos[0], pos[1]
                 if tensor_idx in orig_to_input:
-                    pos = orig_to_input[tensor_idx]
-                    arg = args[pos]
+                    arg_pos = orig_to_input[tensor_idx]
+                    arg = args[arg_pos]
                     if isinstance(arg, torch.Tensor) and dim_idx < len(arg.shape):
-                        value = arg.shape[dim_idx]
+                        actual_dim = arg.shape[dim_idx]
+                        if len(pos) == 4:
+                            a, b = pos[2], pos[3]
+                            value = (actual_dim - b) // a
+                        else:
+                            value = actual_dim
                         dynamic_val[str(key)] = value
                         extra_args.append(value)
                     else:
@@ -982,6 +1170,11 @@ class JitKernel_NPU:
                         val = dynamic_val.get(str(dim))
                         if val is None:
                             raise ValueError(f"Missing value for {dim}")
+                        shape.append(val)
+                    elif isinstance(dim, tir.IntImm):
+                        shape.append(int(dim))
+                    elif isinstance(dim, tir.PrimExpr):
+                        val = _eval_tir_expr(dim, dynamic_val)
                         shape.append(val)
                     else:
                         shape.append(int(dim))


### PR DESCRIPTION
# Fix: Support Composite TIR Expressions in Dynamic Shape Dimensions

## Problem

TileLang npuir JIT 中的 `_process_dynamic_symbolic` 使用 `isinstance(shape, tir.Var)` 严格匹配，
仅能识别 **裸 `tir.Var`** 作为 buffer shape 维度。当 shape 维度为复合 TIR 表达式
（如 `tir.Add(raw_batch_size, 1)`）时，表达式中的符号变量无法被注册进 `dynamic_symbolic_map`，
导致三个连锁失败：

1. **符号变量提升失败** (`_symbolic_var_promoter_pass`): 变量不会被追加为 PrimFunc 参数
2. **Grid 计算失败** (`_calcu_grid`): 运行时无法从 `dynamic_val` 解析 grid 表达式
3. **输出张量分配失败** (`__call__`): 对 `tir.Add` 做 `int(dim)` 抛异常

### 受影响代码位置

| 位置 | 文件 | 行号 |
|------|------|------|
| `_process_dynamic_symbolic` | `tilelang/jit/jit_npu.py` | 114-125 |
| `_symbolic_var_promoter_pass` | `tilelang/jit/jit_npu.py` | 129-151 |
| `_calcu_grid` | `tilelang/jit/jit_npu.py` | 891-949 |
| `__call__` 输出分配 | `tilelang/jit/jit_npu.py` | 976-991 |

## Design

### 核心思路

扩展 `_process_dynamic_symbolic` 使其能从复合 TIR 表达式中提取符号变量，
并通过仿射逆变换在运行时从实际张量维度反解出变量的真实值。

### 新增辅助函数

#### 1. `_collect_tir_vars(expr)` — 收集 TIR 表达式中的所有 `tir.Var`

使用 `tir.stmt_functor.post_order_visit` 遍历表达式树，收集所有 `tir.Var` 节点。

#### 2. `_detect_affine(expr, var)` — 仿射表达式检测

递归检测 `expr` 是否可表示为 `a * var + b`（a, b 为整数常量）。
返回 `(a, b)` 或 `None`。

支持的 TIR 节点类型：
- `tir.Var` → 若为目标 var: `(1, 0)`；否则 `None`
- `tir.IntImm` → `(0, value)`
- `tir.Add` → 左右子树仿射形式相加
- `tir.Sub` → 左右子树仿射形式相减
- `tir.Mul` → 若一侧常数(a=0)，则缩放另一侧
- `tir.FloorDiv` → `expr // const`（仅当分子仿射且分母常量，保守处理）

#### 3. `_eval_tir_expr(expr, dynamic_val)` — 运行时求值

递归求值 TIR 表达式，将 `tir.Var` 替换为 `dynamic_val` 中的实际值。
支持 `Add/Sub/Mul/FloorDiv/Div/Mod/Max/Min` 等常见节点。

### 修改 `_process_dynamic_symbolic`

新算法：
1. **收集所有 vars**：遍历所有 buffer 的所有 shape 维度，用 `_collect_tir_vars` 收集全部 `tir.Var`
2. **优先直接绑定**：对每个 var，优先查找 `shape` 为裸 `tir.Var` 的 buffer/dim
3. **回退仿射绑定**：若无直接绑定，查找 `shape` 为仿射表达式的 buffer/dim，
   用 `_detect_affine` 检测，记录 `(buffer_idx, dim_idx, a, b)`

### map 值格式（向后兼容）

- 直接绑定: `(buffer_idx, dim_idx)` — 长度 2（现有格式不变）
- 仿射绑定: `(buffer_idx, dim_idx, a, b)` — 长度 4

消费方通过 `len(pos)` 判断类型。

### 修改 `_calcu_grid`

```python
for key, pos in self.symbolic.items():
    tensor_idx, dim_idx = pos[0], pos[1]
    actual_dim = args[arg_pos].shape[dim_idx]
    if len(pos) == 4:
        a, b = pos[2], pos[3]
        value = (actual_dim - b) // a
    else:
        value = actual_dim
    dynamic_val[str(key)] = value
```

### 修改 `__call__` 输出分配

```python
for dim in info["shape"]:
    if isinstance(dim, tir.Var):
        val = dynamic_val.get(str(dim))
        shape.append(val)
    elif isinstance(dim, tir.IntImm):
        shape.append(int(dim))
    elif isinstance(dim, tir.PrimExpr):
        val = _eval_tir_expr(dim, dynamic_val)
        shape.append(val)
    else:
        shape.append(int(dim))
```

### 不修改的部分

- `_symbolic_var_promoter_pass` — 仅使用 map keys（`tir.Var` 列表），无需修改
- `_transform_stmt` — 仅按 var name 移除 LetStmt，无需修改
- cython/ctypes adapter — CUDA 路径，不在本次修改范围

## Verification Plan

1. 单元测试 `_collect_tir_vars`、`_detect_affine`、`_eval_tir_expr`
2. 集成测试：构造使用 `[batch_size + 1]` shape 的简单 copy kernel，编译并运行
3. 回归测试：现有 npuir 测试不受影响
