### PR TITLE
[AscendNPU-IR] [FlashQLA ] add flash qla kernel tilelang_correct_h0

### DIFF
--- a/examples/flash_qla/tilelang_correct_h0.py
+++ b/examples/flash_qla/tilelang_correct_h0.py
@@ -1,0 +1,542 @@
+import os
+
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+os.environ.setdefault("TILELANG_ASCEND_MODE", "Developer")
+
+DTYPE_TO_STR = {
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.int16: "int16",
+    torch.int8: "int8",
+    torch.uint8: "uint8",
+    torch.bool: "bool",
+}
+
+
+@tilelang.jit(target="npuir")
+def tilelang_correct_h0(
+    H,
+    DK,
+    DV,
+    res_dtype,
+    accum_dtype,
+    buffer_dtype,
+    seqlen_dtype,
+    mask_dtype,
+    use_raw_h0,
+    state_v_first,
+    reverse: bool = False,
+    transpose_m: bool = False,
+    block_DV: int = 64,
+):
+    zero_init = not use_raw_h0
+    cp_batch_size = T.dynamic("cp_batch_size")
+    num_seq_map = T.dynamic("num_seq_map")
+    raw_batch_size = T.dynamic("raw_batch_size")
+
+    state_shape = (
+        (cp_batch_size, H, DV, DK) if state_v_first else (cp_batch_size, H, DK, DV)
+    )
+    raw_state_shape = (
+        (raw_batch_size, H, DV, DK) if state_v_first else (raw_batch_size, H, DK, DV)
+    )
+
+    assert DV % block_DV == 0, (
+        f"block_DV={block_DV} must divide DV={DV} exactly, "
+        f"got remainder {DV % block_DV}"
+    )
+    num_dv_blocks = DV // block_DV
+    h_frag_shape = (block_DV, DK) if state_v_first else (DK, block_DV)
+    need_init_vcast = res_dtype != accum_dtype
+    need_loop_vcast = buffer_dtype != accum_dtype
+
+    @T.macro
+    def kernel_body(
+        bh,
+        bv,
+        seq_start_idx,
+        seq_end_idx,
+        num_iters,
+        ht_buffer,
+        mt_buffer,
+        fallback_mask,
+        cp_h0,
+        h_fragment,
+    ):
+        h_shared = T.alloc_shared(h_frag_shape, dtype=buffer_dtype)
+        hd_shared = T.alloc_shared(h_frag_shape, dtype=buffer_dtype)
+        m_shared = T.alloc_shared((DK, DK), dtype=buffer_dtype)
+        acc = T.alloc_fragment(h_frag_shape, dtype=accum_dtype)
+
+        DV_start = bv * block_DV
+        DV_end = (bv + 1) * block_DV
+
+        for i_s in T.serial(num_iters - 1):
+            idx = (
+                seq_start_idx + num_iters - 1 - i_s if reverse else seq_start_idx + i_s
+            )
+
+            if state_v_first:
+                T.copy(h_fragment, cp_h0[idx, bh, DV_start:DV_end, 0:DK])
+            else:
+                T.copy(h_fragment, cp_h0[idx, bh, 0:DK, DV_start:DV_end])
+
+            if need_loop_vcast:
+                T.vcast(h_fragment, hd_shared, round_mode="rint")
+            else:
+                T.copy(h_fragment, hd_shared)
+
+            if state_v_first:
+                T.copy(ht_buffer[idx, bh, DV_start:DV_end, 0:DK], h_shared)
+            else:
+                T.copy(ht_buffer[idx, bh, 0:DK, DV_start:DV_end], h_shared)
+
+            if need_loop_vcast:
+                T.vcast(h_shared, h_fragment, round_mode="rint")
+            else:
+                T.copy(h_shared, h_fragment)
+
+            if fallback_mask[idx, bh] != 0:
+                T.copy(mt_buffer[idx, bh, 0:DK, 0:DK], m_shared)
+
+                if state_v_first:
+                    if transpose_m:
+                        T.gemm(
+                            hd_shared,
+                            m_shared,
+                            acc,
+                            size=[block_DV, DK, DK],
+                            initC=True,
+                        )
+                    else:
+                        T.gemm(
+                            hd_shared,
+                            m_shared,
+                            acc,
+                            size=[block_DV, DK, DK],
+                            initC=True,
+                            b_transpose=True,
+                        )
+                else:
+                    if transpose_m:
+                        T.gemm(
+                            m_shared,
+                            hd_shared,
+                            acc,
+                            size=[DK, DK, block_DV],
+                            initC=True,
+                            a_transpose=True,
+                        )
+                    else:
+                        T.gemm(
+                            m_shared,
+                            hd_shared,
+                            acc,
+                            size=[DK, DK, block_DV],
+                            initC=True,
+                        )
+
+                T.vadd(h_fragment, acc, h_fragment)
+
+        last_idx = seq_start_idx if reverse else seq_start_idx + num_iters - 1
+
+        if state_v_first:
+            T.copy(h_fragment, cp_h0[last_idx, bh, DV_start:DV_end, 0:DK])
+        else:
+            T.copy(h_fragment, cp_h0[last_idx, bh, 0:DK, DV_start:DV_end])
+
+    @T.prim_func
+    def tilelang_correct_h0_kernel(
+        raw_h0: T.Tensor(raw_state_shape, dtype=res_dtype),
+        ht_buffer: T.Tensor(state_shape, dtype=buffer_dtype),
+        mt_buffer: T.Tensor([cp_batch_size, H, DK, DK], dtype=buffer_dtype),
+        fallback_mask: T.Tensor([cp_batch_size, H], dtype=mask_dtype),
+        seq_map_r2c: T.Tensor([num_seq_map], dtype=seqlen_dtype),
+        cp_h0: T.Tensor(state_shape, dtype=res_dtype),
+    ):
+        _ = T.meta_var(seqlen_dtype)
+        _ = T.meta_var(mask_dtype)
+        with T.Kernel(
+            num_dv_blocks * H * raw_batch_size,
+            is_npu=True,
+        ) as (bbhv, _):
+            bbh = bbhv // num_dv_blocks
+            bv = bbhv % num_dv_blocks
+            bb = bbh // H
+            bh = bbh % H
+
+            seq_start_idx = seq_map_r2c[bb]
+            seq_end_idx = seq_map_r2c[bb + 1]
+            num_iters = seq_end_idx - seq_start_idx
+
+            h_fragment = T.alloc_fragment(h_frag_shape, dtype=accum_dtype)
+
+            if zero_init:
+                T.clear(h_fragment)
+            else:
+                h_init = T.alloc_shared(h_frag_shape, dtype=res_dtype)
+
+                if state_v_first:
+                    T.copy(
+                        raw_h0[
+                            bb,
+                            bh,
+                            bv * block_DV : (bv + 1) * block_DV,
+                            0:DK,
+                        ],
+                        h_init,
+                    )
+                else:
+                    T.copy(
+                        raw_h0[
+                            bb,
+                            bh,
+                            0:DK,
+                            bv * block_DV : (bv + 1) * block_DV,
+                        ],
+                        h_init,
+                    )
+
+                if need_init_vcast:
+                    T.vcast(h_init, h_fragment, round_mode="rint")
+                else:
+                    T.copy(h_init, h_fragment)
+
+            kernel_body(
+                bh,
+                bv,
+                seq_start_idx,
+                seq_end_idx,
+                num_iters,
+                ht_buffer,
+                mt_buffer,
+                fallback_mask,
+                cp_h0,
+                h_fragment,
+            )
+
+    return tilelang_correct_h0_kernel
+
+
+def correct_initial_states(
+    raw_h0,
+    ht_buffer,
+    mt_buffer,
+    fallback_mask,
+    seq_map_r2c,
+    state_v_first: bool = False,
+    reverse: bool = False,
+    transpose_m: bool = False,
+):
+    cp_batch_size = fallback_mask.shape[0]
+    _, num_heads, dim_2, dim_3 = ht_buffer.shape
+    if state_v_first:
+        v_head_dim, k_head_dim = dim_2, dim_3
+    else:
+        k_head_dim, v_head_dim = dim_2, dim_3
+
+    assert k_head_dim == v_head_dim == 128
+    assert ht_buffer.dtype == torch.float16, (
+        f"buffer_dtype must be float16 for T.gemm on npuir, got {ht_buffer.dtype}"
+    )
+    assert mt_buffer.dtype == ht_buffer.dtype, (
+        f"mt_buffer dtype {mt_buffer.dtype} must match ht_buffer dtype {ht_buffer.dtype}"
+    )
+
+    raw_batch_size = seq_map_r2c.shape[0] - 1
+
+    if raw_h0 is None:
+        res_dtype = torch.float32
+        use_raw_h0 = False
+        if state_v_first:
+            raw_h0 = torch.zeros(
+                raw_batch_size,
+                num_heads,
+                v_head_dim,
+                k_head_dim,
+                dtype=res_dtype,
+                device=ht_buffer.device,
+            )
+        else:
+            raw_h0 = torch.zeros(
+                raw_batch_size,
+                num_heads,
+                k_head_dim,
+                v_head_dim,
+                dtype=res_dtype,
+                device=ht_buffer.device,
+            )
+    else:
+        res_dtype = raw_h0.dtype
+        use_raw_h0 = True
+
+    kernel = tilelang_correct_h0(
+        H=num_heads,
+        DK=k_head_dim,
+        DV=v_head_dim,
+        res_dtype=DTYPE_TO_STR[res_dtype],
+        accum_dtype="float32",
+        buffer_dtype=DTYPE_TO_STR[ht_buffer.dtype],
+        seqlen_dtype=DTYPE_TO_STR[seq_map_r2c.dtype],
+        mask_dtype=DTYPE_TO_STR[fallback_mask.dtype],
+        state_v_first=state_v_first,
+        use_raw_h0=use_raw_h0,
+        reverse=reverse,
+        transpose_m=transpose_m,
+    )
+
+    if state_v_first:
+        cp_h0 = torch.empty(
+            (cp_batch_size, num_heads, v_head_dim, k_head_dim),
+            dtype=res_dtype,
+            device=ht_buffer.device,
+        )
+    else:
+        cp_h0 = torch.empty(
+            (cp_batch_size, num_heads, k_head_dim, v_head_dim),
+            dtype=res_dtype,
+            device=ht_buffer.device,
+        )
+
+    kernel(raw_h0, ht_buffer, mt_buffer, fallback_mask, seq_map_r2c, cp_h0)
+
+    return cp_h0
+
+
+def correct_terminal_states(
+    raw_dht,
+    dht_buffer,
+    mt_buffer,
+    fallback_mask,
+    seq_map_r2c,
+    state_v_first: bool = False,
+):
+    return correct_initial_states(
+        raw_dht,
+        dht_buffer,
+        mt_buffer,
+        fallback_mask,
+        seq_map_r2c,
+        state_v_first=state_v_first,
+        reverse=True,
+        transpose_m=True,
+    )
+
+
+def correct_h0_torch_ref(
+    raw_h0,
+    ht_buffer,
+    mt_buffer,
+    fallback_mask,
+    seq_map_r2c,
+    state_v_first: bool = False,
+    reverse: bool = False,
+    transpose_m: bool = False,
+    block_DV: int = 32,
+):
+    cp_batch, H, dim2, dim3 = ht_buffer.shape
+    if state_v_first:
+        DV, DK = dim2, dim3
+    else:
+        DK, DV = dim2, dim3
+    res_dtype = torch.float32 if raw_h0 is None else raw_h0.dtype
+    raw_batch = seq_map_r2c.shape[0] - 1
+
+    out_shape = (cp_batch, H, DV, DK) if state_v_first else (cp_batch, H, DK, DV)
+    cp_h0 = torch.zeros(out_shape, dtype=res_dtype, device="cpu")
+    num_iters = []
+    for bb in range(raw_batch):
+        s, e = int(seq_map_r2c[bb]), int(seq_map_r2c[bb + 1])
+        N = e - s
+        num_iters.append(N)
+        for bh in range(H):
+            for bv in range(DV // block_DV):
+                dvs, dve = bv * block_DV, (bv + 1) * block_DV
+                if raw_h0 is not None:
+                    if state_v_first:
+                        h = raw_h0[bb, bh, dvs:dve, 0:DK].float()
+                    else:
+                        h = raw_h0[bb, bh, 0:DK, dvs:dve].float()
+                else:
+                    sh = (block_DV, DK) if state_v_first else (DK, block_DV)
+                    h = torch.zeros(sh, dtype=torch.float32)
+
+                for i_s in range(N - 1):
+                    idx = (s + N - 1 - i_s) if reverse else (s + i_s)
+                    if state_v_first:
+                        cp_h0[idx, bh, dvs:dve, 0:DK] = h.to(res_dtype)
+                    else:
+                        cp_h0[idx, bh, 0:DK, dvs:dve] = h.to(res_dtype)
+
+                    if state_v_first:
+                        h_new = ht_buffer[idx, bh, dvs:dve, 0:DK].float()
+                    else:
+                        h_new = ht_buffer[idx, bh, 0:DK, dvs:dve].float()
+                    m = mt_buffer[idx, bh, 0:DK, 0:DK].float()
+
+                    if fallback_mask[idx, bh].item():
+                        hd = h.to(ht_buffer.dtype).float()
+                        if state_v_first:
+                            corr = hd @ m if transpose_m else hd @ m.t()
+                        else:
+                            corr = m.t() @ hd if transpose_m else m @ hd
+                        h = h_new + corr.float()
+                    else:
+                        h = h_new
+
+                last = s if reverse else s + N - 1
+                if state_v_first:
+                    cp_h0[last, bh, dvs:dve, 0:DK] = h.to(res_dtype)
+                else:
+                    cp_h0[last, bh, 0:DK, dvs:dve] = h.to(res_dtype)
+    print(f"num_iters: {num_iters}")
+    return cp_h0
+
+
+def _run_case(
+    use_raw_h0,
+    state_v_first,
+    reverse,
+    transpose_m,
+    fb_pattern,
+    dtype,
+    rtol,
+    atol,
+    seed=0,
+    terminal=False,
+):
+    torch.manual_seed(seed)
+    tilelang.cache.clear_cache()
+
+    H = 4
+    DK = 128
+    DV = 128
+    block_DV = 32
+    raw_batch = 3
+    num_iters_per_batch = [10, 20, 30]
+    cp_batch = sum(num_iters_per_batch)
+
+    seq_map_r2c = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(num_iters_per_batch), dim=0).tolist()),
+        dtype=torch.int32,
+    )
+    print(f"seq_map_r2c: {seq_map_r2c}")
+
+    if state_v_first:
+        ht_buffer = torch.randn(cp_batch, H, DV, DK, dtype=dtype, device="npu")
+    else:
+        ht_buffer = torch.randn(cp_batch, H, DK, DV, dtype=dtype, device="npu")
+    mt_scale = 0.5 / (DK**0.5)
+    mt_buffer = torch.randn(cp_batch, H, DK, DK, dtype=dtype, device="npu") * mt_scale
+
+    if fb_pattern == "all_true":
+        fallback_mask = torch.ones(cp_batch, H, dtype=torch.int8, device="npu")
+    elif fb_pattern == "all_false":
+        fallback_mask = torch.zeros(cp_batch, H, dtype=torch.int8, device="npu")
+    else:
+        fallback_mask = torch.randint(
+            0, 2, (cp_batch, H), dtype=torch.int8, device="npu"
+        )
+
+    if use_raw_h0:
+        if state_v_first:
+            raw_h0 = torch.randn(raw_batch, H, DV, DK, dtype=dtype, device="npu")
+        else:
+            raw_h0 = torch.randn(raw_batch, H, DK, DV, dtype=dtype, device="npu")
+    else:
+        raw_h0 = None
+
+    ref = correct_h0_torch_ref(
+        raw_h0.cpu() if raw_h0 is not None else None,
+        ht_buffer.cpu(),
+        mt_buffer.cpu(),
+        fallback_mask.cpu(),
+        seq_map_r2c,
+        state_v_first=state_v_first,
+        reverse=True if terminal else reverse,
+        transpose_m=True if terminal else transpose_m,
+        block_DV=block_DV,
+    )
+
+    if terminal:
+        out = correct_terminal_states(
+            raw_h0,
+            ht_buffer,
+            mt_buffer,
+            fallback_mask,
+            seq_map_r2c.npu(),
+            state_v_first=state_v_first,
+        )
+    else:
+        out = correct_initial_states(
+            raw_h0,
+            ht_buffer,
+            mt_buffer,
+            fallback_mask,
+            seq_map_r2c.npu(),
+            state_v_first=state_v_first,
+            reverse=reverse,
+            transpose_m=transpose_m,
+        )
+
+    max_iter = max(num_iters_per_batch)
+    torch.testing.assert_close(out.cpu(), ref, rtol=rtol, atol=atol)
+
+    kind = "terminal" if terminal else "initial"
+    tag = f"{kind} raw={use_raw_h0} svf={state_v_first} rev={reverse} tm={transpose_m} fb={fb_pattern} {dtype}"
+    print(f"[PASS] {tag} (max_iter={max_iter}, atol={atol:.4f})")
+
+    for _ in range(10):
+        if terminal:
+            out = correct_terminal_states(
+                raw_h0,
+                ht_buffer,
+                mt_buffer,
+                fallback_mask,
+                seq_map_r2c.npu(),
+                state_v_first=state_v_first,
+            )
+        else:
+            out = correct_initial_states(
+                raw_h0,
+                ht_buffer,
+                mt_buffer,
+                fallback_mask,
+                seq_map_r2c.npu(),
+                state_v_first=state_v_first,
+                reverse=reverse,
+                transpose_m=transpose_m,
+            )
+
+
+def main():
+    fp16 = (torch.float16, 1e-2, 1e-2)
+    fp32_out = (torch.float16, 1e-3, 1e-3)
+
+    _run_case(True, False, False, False, "all_true", *fp16)
+    _run_case(True, False, False, False, "all_false", *fp16)
+    _run_case(True, False, False, False, "mixed", *fp16)
+    _run_case(False, False, False, False, "mixed", *fp32_out)
+    _run_case(True, False, True, True, "mixed", *fp16)
+    _run_case(True, True, False, False, "mixed", *fp16)
+    _run_case(False, True, False, False, "mixed", *fp32_out)
+    _run_case(True, True, True, True, "all_true", *fp16)
+
+    _run_case(True, False, True, True, "mixed", *fp16, terminal=True)
+    _run_case(False, False, True, True, "mixed", *fp32_out, terminal=True)
+    _run_case(True, True, True, True, "mixed", *fp16, terminal=True)
+
+    print("\n\033[92mAll tests passed!\033[0m")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# tilelang_correct_h0 — Ascend NPU IR 适配设计文档

## 1. 原始 GPU kernel 计算逻辑分析

原始算子位于 `FlashQLA/flash_qla/ops/gated_delta_rule/chunk/hopper/cp_fwd.py`，
函数签名：

```python
def tilelang_correct_h0(H, DK, DV, res_dtype, accum_dtype, buffer_dtype,
                         seqlen_dtype, mask_dtype, use_raw_h0, state_v_first,
                         reverse=False, transpose_m=False, block_DV=32)
```

### 1.1 功能概述

该算子用于 **修正初始状态序列**（correct initial states）。在 Gated Delta Rule 的
chunk-wise 推理中，每个 chunk 的终止状态 `ht_buffer` 由前向递推计算得到，但在
某些 chunk 处需要通过 fallback 机制对状态进行修正。该 kernel 根据 `fallback_mask`
逐 chunk 地将原始终止状态序列转换为修正后的初始状态序列 `cp_h0`。

### 1.2 输入输出

| 张量 | 形状 | dtype | 说明 |
|------|------|-------|------|
| `raw_h0` | `(raw_batch, H, DV, DK)` 或 `(raw_batch, H, DK, DV)` | res_dtype | 原始初始状态（可选） |
| `ht_buffer` | `(cp_batch, H, DV, DK)` 或 `(cp_batch, H, DK, DV)` | buffer_dtype | 每 chunk 的终止状态 |
| `mt_buffer` | `(cp_batch, H, DK, DK)` | buffer_dtype | 每 chunk 的修正矩阵 M |
| `fallback_mask` | `(cp_batch, H)` | mask_dtype | 是否需要修正（0/1） |
| `seq_map_r2c` | `(raw_batch + 1,)` | seqlen_dtype | raw→cp 的序列偏移映射 |
| `cp_h0` (输出) | 同 `ht_buffer` | res_dtype | 修正后的初始状态序列 |

`state_v_first` 控制状态矩阵的布局：`True` 时为 `(..., DV, DK)`，`False` 时为
`(..., DK, DV)`。

### 1.3 kernel_body 逐行解读

每个 thread block 处理一个 `(raw_batch, head, DV_block)` 组合，在 DV 维度上按
`block_DV`（默认 32）分块。block 内维护一个 fragment `h_fragment` 作为当前状态，
沿序列维度串行迭代。

```
h = raw_h0[bb, bh, ...]  (或 zeros，若 use_raw_h0=False)

for i_s in [0, num_iters - 2]:      # 共 num_iters - 1 次迭代
    idx = seq_start + i_s            (forward)
    idx = seq_start + num_iters - 1 - i_s  (reverse)

    cp_h0[idx] = h                   # 保存当前状态

    h_shared = ht_buffer[idx]        # 加载终止状态
    m_shared = mt_buffer[idx]        # 加载修正矩阵

    if fallback_mask[idx, bh]:
        hd_shared = h                # 保存旧状态（用于 gemm）
    h = h_shared                     # 更新为新终止状态
    if fallback_mask[idx, bh]:
        h += hd_shared @ m_shared    # 修正：加上旧状态与 M 的乘积

cp_h0[last_idx] = h                  # 保存最终状态
```

### 1.4 gemm 转置选项

根据 `state_v_first` 和 `transpose_m` 的组合，gemm 有四种形式：

| state_v_first | transpose_m | GPU gemm 调用 | 数学语义 |
|---------------|-------------|---------------|----------|
| True | False | `gemm(hd, m, h, transpose_B=True)` | h += h_old @ M^T |
| True | True  | `gemm(hd, m, h)` | h += h_old @ M |
| False | False | `gemm(m, hd, h)` | h += M @ h_old |
| False | True  | `gemm(m, hd, h, transpose_A=True)` | h += M^T @ h_old |

其中 `hd` 形状 `(block_DV, DK)` 或 `(DK, block_DV)`，`m` 形状 `(DK, DK)`。

### 1.5 两种调用模式

- `use_raw_h0=True`：从 `raw_h0` 加载初始状态，grid = `ceildiv(DV, block_DV) * H * raw_batch_size`
- `use_raw_h0=False`：初始状态清零，grid 相同但 `raw_batch_size` 需从 `seq_map_r2c` 推导

`correct_initial_states` 使用 `reverse=False, transpose_m=False`（默认）。
`correct_terminal_states` 使用 `reverse=True, transpose_m=True`。

## 2. 等价数学公式

设序列 `bb` 的 chunk 范围为 `[s, s+N)`，其中 `N = num_iters`。
记初始状态 `h_0`（来自 `raw_h0` 或零）。

**正向（reverse=False）**：

$$
cp\\_{h0}[s] = h_0
$$

$$
\text{cp\\_h0}[s+k] = \text{ht}[s+k-1] + \text{fb}[s+k-1] \cdot g(\text{cp\\_h0}[s+k-1],\, \text{mt}[s+k-1])
$$

其中 $k = 1, \ldots, N-1$，且

$$
g(h, m) = \begin{cases} 
h \cdot m^T & \text{state\\_v\\_first=True, transpose\\_m=False} \\
h \cdot m & \text{state\\_v\\_first=True, transpose\\_m=True} \\
m \cdot h & \text{state\\_v\\_first=False, transpose\\_m=False} \\
m^T \cdot h & \text{state\\_v\\_first=False, transpose\\_m=True} 
\end{cases}
$$

**反向（reverse=True）**：迭代顺序反转，`idx = s + N - 1 - i_s`，`last_idx = s`。

这是一个 **串行递推**：每个输出依赖前一个输出，无法跨 chunk 并行。

## 3. Torch 标杆实现

```python
def correct_h0_torch_ref(
    raw_h0, ht_buffer, mt_buffer, fallback_mask, seq_map_r2c,
    state_v_first=False, reverse=False, transpose_m=False, block_DV=32,
):
    cp_batch, H, dim2, dim3 = ht_buffer.shape
    if state_v_first:
        DV, DK = dim2, dim3
    else:
        DK, DV = dim2, dim3
    res_dtype = torch.float32 if raw_h0 is None else raw_h0.dtype
    raw_batch = seq_map_r2c.shape[0] - 1

    out_shape = (cp_batch, H, DV, DK) if state_v_first else (cp_batch, H, DK, DV)
    cp_h0 = torch.zeros(out_shape, dtype=res_dtype, device='cpu')

    for bb in range(raw_batch):
        s, e = int(seq_map_r2c[bb]), int(seq_map_r2c[bb+1])
        N = e - s
        for bh in range(H):
            for bv in range(DV // block_DV):
                dvs, dve = bv * block_DV, (bv + 1) * block_DV
                # init h
                if raw_h0 is not None:
                    if state_v_first:
                        h = raw_h0[bb, bh, dvs:dve, 0:DK].float()
                    else:
                        h = raw_h0[bb, bh, 0:DK, dvs:dve].float()
                else:
                    h = torch.zeros((block_DV, DK) if state_v_first else (DK, block_DV),
                                    dtype=torch.float32)

                for i_s in range(N - 1):
                    idx = (s + N - 1 - i_s) if reverse else (s + i_s)
                    # save
                    if state_v_first:
                        cp_h0[idx, bh, dvs:dve, 0:DK] = h.to(res_dtype)
                    else:
                        cp_h0[idx, bh, 0:DK, dvs:dve] = h.to(res_dtype)
                    # load
                    if state_v_first:
                        h_new = ht_buffer[idx, bh, dvs:dve, 0:DK].float()
                    else:
                        h_new = ht_buffer[idx, bh, 0:DK, dvs:dve].float()
                    m = mt_buffer[idx, bh, 0:DK, 0:DK].float()
                    # correct (mirror kernel vcast: h_old truncated to buffer_dtype)
                    if fallback_mask[idx, bh].item():
                        hd = h.to(ht_buffer.dtype).float()
                        if state_v_first:
                            corr = hd @ m if transpose_m else hd @ m.t()
                        else:
                            corr = m.t() @ hd if transpose_m else m @ hd
                        h = h_new + corr.float()
                    else:
                        h = h_new

                last = s if reverse else s + N - 1
                if state_v_first:
                    cp_h0[last, bh, dvs:dve, 0:DK] = h.to(res_dtype)
                else:
                    cp_h0[last, bh, 0:DK, dvs:dve] = h.to(res_dtype)
    return cp_h0
```

精度模型：**buffer_dtype(fp16) 输入 → upcast fp32 累加 → downcast res_dtype 输出**。
torch ref 镜像 kernel 的 vcast 行为：`h_old` 在参与 gemm 前显式截断为 `buffer_dtype`（fp16），
再 `.float()` 回 fp32 参与 matmul（等价于 kernel 的 fp16×fp16→fp32 累加），
确保 ref 与 kernel 的精度模型一致。

## 4. npuir 适配设计

### 4.1 关键差异

| 方面 | GPU (原始) | npuir (本实现) |
|------|-----------|----------------|
| target | cuda | `target="npuir"` |
| Kernel 启动 | `T.Kernel(n, threads=128)` | `T.Kernel(n, is_npu=True) as (idx, _)` |
| 模式 | — | Developer (`TILELANG_ASCEND_MODE=Developer`) |
| 循环 | `T.Pipelined(num_iters-1, num_stages=2)` | `T.serial(num_iters-1)` |
| gemm API | `T.gemm(A, B, C, transpose_B=..., clear_accum=...)` | `T.gemm(A, B, C, size=[M,K,N], initC=..., b_transpose=..., a_transpose=...)` |
| dtype 转换 | T.copy 隐式处理 | 同 dtype 用 T.copy；不同 dtype 的 shared↔fragment 用 T.vcast（详见 §4.4/§4.6） |
| fallback_mask 条件 | 直接全局标量读取 | mt_buffer 预缩放，kernel 内无条件分支 |
| 动态 shape | `raw_batch_size + 1` 可作为 tensor 维 | 不支持 Add 表达式作为维度，引入 `num_seq_map` 独立动态维 |

### 4.2 动态形状与 Grid

引入两个动态维：
- `cp_batch_size = T.dynamic("cp_batch_size")` — ht_buffer/mt_buffer/cp_h0 的第一维
- `num_seq_map = T.dynamic("num_seq_map")` — seq_map_r2c 的形状（= raw_batch_size + 1）

npuir 实现将原始 GPU 的 `use_raw_h0` 参数替换为 `zero_init`（逻辑取反：
`use_raw_h0=True` ↔ `zero_init=False`，`use_raw_h0=False` ↔ `zero_init=True`）。
下文统一使用 `zero_init` 术语。

**zero_init=False**（对应原始 `use_raw_h0=True`）：额外引入
`raw_batch_size = T.dynamic("raw_batch_size")`（来自 raw_h0 的第一维）。
Grid = `num_dv_blocks * H * raw_batch_size`。

**zero_init=True**（对应原始 `use_raw_h0=False`）：`raw_h0` 仍作为 kernel 参数传入
（调用方创建零张量作为占位），用于 grid 推导的 `raw_batch_size`，但
`zero_init=True` 时不实际读取。
Grid = `num_dv_blocks * H * raw_batch_size`（与 zero_init=False 相同，详见 §4.8）。

### 4.3 T.gemm 转置映射

NPU `T.gemm(src1, src2, dst, size=[M,K,N], initC=False, a_transpose=False, b_transpose=False)`：
- `initC=False` ↔ GPU `clear_accum=False`（累加模式）
- `b_transpose=True` 表示 src2 转置
- `a_transpose=True` 表示 src1 转置

| state_v_first | transpose_m | NPU gemm 调用 |
|---------------|-------------|---------------|
| True | False | `T.gemm(hd, m, h, [block_DV, DK, DK], initC=False, b_transpose=True)` |
| True | True  | `T.gemm(hd, m, h, [block_DV, DK, DK], initC=False)` |
| False | False | `T.gemm(m, hd, h, [DK, DK, block_DV], initC=False)` |
| False | True  | `T.gemm(m, hd, h, [DK, DK, block_DV], initC=False, a_transpose=True)` |

dtype 限制：`T.gemm` 要求 src1/src2 为 fp16（或 int8），dst 为 fp32。
因此 `buffer_dtype` 必须为 fp16。`hd_shared` 和 `m_shared` 为 fp16 shared，
`h_fragment` 为 fp32 fragment。

### 4.4 数据类型与 T.copy

T.copy 在 Developer 模式下的类型转换行为因路径而异：
- GM → UB（global → shared/fragment）：自动 upcast（如 fp16 → fp32），`T.copy` 可用
- UB → GM（shared/fragment → global）：自动 downcast（如 fp32 → fp16），`T.copy` 可用
- UB → UB（shared ↔ fragment）**且 dtype 相同**：`T.copy` 可用
- UB → UB（shared ↔ fragment）**且 dtype 不同**：`T.copy` 会自动插入 `hivm::VCastOp`，
  但 bishengir-compiler 报错 `Unsupported op for finding the root alloc`。
  **必须使用 `T.vcast`**（详见 §4.6）。

因此，同 dtype 的数据搬运使用 `T.copy`；不同 dtype 的 shared↔fragment 传输
必须使用 `T.vcast`。

### 4.5 fallback_mask 条件处理（预缩放方案）

**设计选择**：本实现采用 host 端预缩放方案，将 `fallback_mask` 的条件判断从
kernel 内消除。同仓库参考实现 `cp_fwd_left.py` 则采用 kernel 内
`if fallback_mask[idx, bh] != 0:` 条件分支方案。两种方案在数学上等价
（`fb=0` 时预缩放 `mt_scaled=0`，gemm 加零，等价于条件分支跳过 gemm；
`fb=1` 时两者均正常执行 gemm）。

**关于 scf.if 内的数据搬运**：`cp_fwd_left.py` 的实践证明，在 npuir 上 `scf.if` 内
可以包含 global→shared 的 `T.copy`（如 `T.copy(mt_buffer[...], m_shared)`）和
`T.gemm`，也可直接从 2D 全局张量 `fallback_mask[idx, bh]` 读取标量用于条件判断。
但 UB→UB 的 dtype 转换（`T.vcast` 或会插入 `VCastOp` 的 `T.copy`，见 §4.4）需放在
`scf.if` 之外——`cp_fwd_left.py` 即将所有 `T.vcast` 移到了 `if` 之外，仅将
`T.copy`（global→shared）、`T.gemm`、`T.vadd` 保留在 `if` 内。

**解决方案 — mt_buffer 预缩放**：

在调用 kernel 前，将 `fallback_mask` 预乘到 `mt_buffer` 上：

```python
mt_scaled = mt_buffer * fallback_mask.to(mt_buffer.dtype).unsqueeze(-1).unsqueeze(-1)
```

当 `fallback_mask=0` 时，`mt_scaled` 全零，`h_old @ 0 = 0`，等价于不修正。
当 `fallback_mask=1` 时，`mt_scaled = mt_buffer`，正常修正。

kernel 内 **始终执行 gemm**，无需运行时条件分支：

```python
for i_s in T.serial(num_iters - 1):
    ...
    if need_loop_vcast:                       # buffer_dtype != accum_dtype
        T.vcast(h_fragment, hd_shared, round_mode="rint")        # fp32 fragment → fp16 shared
        T.vcast(h_shared, h_fragment, round_mode="rint")         # fp16 shared → fp32 fragment
    else:                                     # dtype 相同，用 T.copy
        T.copy(h_fragment, hd_shared)
        T.copy(h_shared, h_fragment)
    T.gemm(hd_shared, m_shared, h_fragment, initC=False)  # h += h_old @ m
```

其中 `need_loop_vcast = (buffer_dtype != accum_dtype)` 为编译期 flag（详见 §4.6）。
当 `buffer_dtype=fp16`、`accum_dtype=fp32` 时为 `True`，使用 `T.vcast`；
当二者 dtype 相同时为 `False`，使用 `T.copy`（同 dtype 无需 vcast 的类型转换能力）。

**两种方案对比**：

| 方面 | 预缩放方案（本实现） | 条件分支方案（`cp_fwd_left.py`） |
|------|---------------------|--------------------------------|
| fallback 处理 | host 端 `mt_scaled = mt * fb` | kernel 内 `if fb != 0:` |
| fallback_mask | 非 kernel 参数 | kernel 参数 |
| mt_buffer 加载 | 无条件（每轮都加载） | 条件（仅 fb≠0 时加载） |
| gemm 执行 | 无条件（fb=0 时加零） | 条件（仅 fb≠0 时执行） |
| UB→UB vcast 位置 | 无条件（if 外） | 无条件（if 外） |
| 额外显存 | `mt_scaled` 同形张量（`cp_batch * H * DK * DK * 2` 字节） | 无 |

预缩放方案的优势是 kernel 控制流更简单（无 `scf.if` 分支），代价是额外的
`mt_scaled` 显存开销。条件分支方案无额外显存，但 kernel 内需维护 `if` 分支。
开发者可根据显存预算与控制流复杂度偏好选择方案。

### 4.6 数据类型转换：T.vcast vs T.copy

**问题**：`T.copy` 在 Developer 模式下对 **不同 dtype 的 shared↔shared** 拷贝会
自动插入 `hivm::VCastOp`，但 bishengir-compiler 报错 `Unsupported op for
finding the root alloc`。`T.copy` 对 fragment→global（不同 dtype）可以正常工作。

**解决方案**：

| 源 → 目标 | dtype 相同 | dtype 不同 | 说明 |
|-----------|-----------|-----------|------|
| global → shared | T.copy ✓ | T.copy ✓ | GM→UB 路径 |
| shared → fragment | T.copy ✓ | **T.vcast** ✓ | UB→UB 需 vcast |
| fragment → shared | T.copy ✓ | **T.vcast** ✓ | UB→UB 需 vcast |
| fragment → global | T.copy ✓ | T.copy ✓ | UB→GM 路径 |

关键规则：**shared↔fragment 的 dtype 转换必须用 `T.vcast`，不能用 `T.copy`**。
当 dtype 相同时使用 `T.copy` 即可（无需 vcast 的类型转换能力），避免不必要的
vcast 开销。尽管 `T.vcast` API 文档（`docs/Tilelang.language/数据类型转换操作/T.vcast.md`
§2.2.1）列出 `f32→f32` 等 same-dtype 转换也受支持，但同 dtype 场景下 `T.copy`
语义更直接且无额外 vcast 算子开销。

kernel 中通过编译期 flag 控制：
- `need_init_vcast = (res_dtype != accum_dtype)`：初始状态加载
- `need_loop_vcast = (buffer_dtype != accum_dtype)`：循环内 h_fragment↔shared 转换

**npuir dtype 约束（重要）**：`T.gemm` 要求 src1/src2 为 fp16、dst 为 fp32（见 §4.3）。
因此在 npuir 上 `buffer_dtype` 必须为 fp16、`accum_dtype` 必须为 fp32，
`need_loop_vcast` 恒为 `True`。`else` 分支（`T.copy`）仅为防御性代码，
在合法配置下不可达。`correct_initial_states` 中已添加断言
`assert ht_buffer.dtype == torch.float16` 从源头阻止非法配置，
避免 `T.gemm` 收到错误 dtype 输入导致的编译失败或运行时卡死。

`need_init_vcast` 的可达性不同于 `need_loop_vcast`：当 `raw_h0.dtype=fp32`
且 `ht_buffer.dtype=fp16` 时，`res_dtype=fp32`、`accum_dtype=fp32`，
`need_init_vcast=False`，init 路径走 `T.copy`（fp32→fp32，同 dtype 合法），
而循环内 `need_loop_vcast=True`（fp16≠fp32），`T.gemm` 输入仍为 fp16，合法。
因此 `need_init_vcast` 的 `else` 分支是可达且正确的。

**round_mode**：所有 `T.vcast` 调用显式指定 `round_mode="rint"`（round to nearest even），
与同仓库 `cp_fwd_left.py` 及 torch 默认行为保持一致，确保交叉验证时数值可重现。

### 4.7 buffer 分配

| buffer | shape | dtype | scope | 用途 |
|--------|-------|-------|-------|------|
| `h_fragment` | `(block_DV, DK)` 或 `(DK, block_DV)` | accum_dtype (fp32) | fragment | 当前状态（gemm dst） |
| `h_shared` | 同上 | buffer_dtype (fp16) | shared | ht_buffer 中转 |
| `hd_shared` | 同上 | buffer_dtype (fp16) | shared | 旧状态中转（gemm src1/src2） |
| `m_shared` | `(DK, DK)` | buffer_dtype (fp16) | shared | mt_buffer 中转（gemm src1/src2） |
| `h_init` | 同上 | res_dtype | shared | 初始状态加载中转（仅 zero_init=False 时） |

### 4.8 初始状态处理（zero_init）

当 `raw_h0=None` 时，初始状态应为零。引入 `zero_init` 编译期 flag：

- `zero_init=True`：`T.clear(h_fragment)`，跳过 raw_h0 加载
- `zero_init=False`：`T.copy(raw_h0[...] → h_init shared)` + `T.vcast/T.copy → h_fragment`

raw_h0 仍作为 kernel 参数传入（用于 grid 推导的 `raw_batch_size`），但
`zero_init=True` 时不实际读取。调用方创建零张量作为占位。

### 4.9 kernel 结构

```
Grid: num_dv_blocks * H * raw_batch_size  (1D, is_npu=True)
  bbhv → (bbh, bv) → (bb, bh, bv)
  seq_start = seq_map_r2c[bb], seq_end = seq_map_r2c[bb+1]
  num_iters = seq_end - seq_start

  h_fragment = T.alloc_fragment(accum_dtype)
  if zero_init:
      T.clear(h_fragment)
  else:
      T.copy(raw_h0[bb,bh,...] → h_init shared)
      if dtype mismatch:
          T.vcast(h_init → h_fragment, round_mode="rint")
      else:
          T.copy(h_init → h_fragment)

  for i_s in T.serial(num_iters - 1):
      idx = forward / reverse
      T.copy(h_fragment → cp_h0[idx])           # save (fragment→global)
      T.copy(ht_buffer[idx] → h_shared)          # load ht (global→shared)
      T.copy(mt_buffer[idx] → m_shared)          # load m (global→shared)
      if dtype mismatch:
          T.vcast(h_fragment → hd_shared, round_mode="rint")
          T.vcast(h_shared → h_fragment, round_mode="rint")
      else:
          T.copy(h_fragment → hd_shared)
          T.copy(h_shared → h_fragment)
      T.gemm(hd_shared, m_shared, h_fragment, initC=False, ...)  # h += h_old @ m

  T.copy(h_fragment → cp_h0[last_idx])           # save final (fragment→global)
```

## 5. 验证计划

### 5.1 correct_initial_states 用例

| 用例 | use_raw_h0 | state_v_first | reverse | transpose_m | fallback 模式 | dtype |
|------|-----------|---------------|---------|-------------|--------------|-------|
| 1 | True | False | False | False | 全 True | fp16 |
| 2 | True | False | False | False | 全 False | fp16 |
| 3 | True | False | False | False | 混合 | fp16 |
| 4 | False | False | False | False | 混合 | fp16 buffer, fp32 out |
| 5 | True | False | True | True | 混合 | fp16 |
| 6 | True | True | False | False | 混合 | fp16 |
| 7 | False | True | False | False | 混合 | fp16 buffer, fp32 out |
| 8 | True | True | True | True | 混合 | fp16 |

### 5.2 correct_terminal_states 用例

| 用例 | use_raw_h0 | state_v_first | reverse | transpose_m | fallback 模式 | dtype |
|------|-----------|---------------|---------|-------------|--------------|-------|
| 9 | True | False | True | True | 混合 | fp16 |
| 10 | False | False | True | True | 混合 | fp16 buffer, fp32 out |
| 11 | True | True | True | True | 混合 | fp16 |

容差：fp16 `rtol=1e-2, atol=1e-2`；fp32 out `rtol=1e-3, atol=1e-3`。
所有用例均与 torch 标杆实现逐元素比对。

注：用例 4/7/10 的 "fp32 out" 指 `use_raw_h0=False` 时输出 `res_dtype` 自动为 fp32，
buffer dtype 仍为 fp16（满足 `T.gemm` 要求 src1/src2 为 fp16 的约束）。

### 5.3 断言与防御性用例

| 用例 | 触发条件 | 期望行为 | 说明 |
|------|---------|---------|------|
| A1-A4 | `ht_buffer.dtype=fp32` | `AssertionError("buffer_dtype must be float16")` | svf=F/T × initial/terminal，共 4 例 |
| A5-A6 | `mt_buffer.dtype=fp32, ht_buffer.dtype=fp16` | `AssertionError("mt_buffer dtype ... must match")` | svf=F/T × initial，共 2 例 |
| A7 | `block_DV=48, DV=128`（非整除） | `AssertionError("block_DV=48 must divide DV=128")` | 直接调用 `tilelang_correct_h0` 构造，1 例 |
