### PR TITLE
Lower tl.npuir_sub from hivm to linalg dialect in codegen_npuir_api_a5

### DIFF
--- a/src/target/codegen_npuir_api_a5.cc
+++ b/src/target/codegen_npuir_api_a5.cc
@@ -291,6 +291,34 @@ namespace {
   };
 }  // namespace
 
+
+template <auto V> struct ElemwiseOp;
+
+template <linalg::BinaryFn V> struct ElemwiseOp<V> {
+  using Op = linalg::ElemwiseBinaryOp;
+  using FnAttr = linalg::BinaryFnAttr;
+  static constexpr linalg::BinaryFn Fn = V;
+};
+
+template <hfusion::BinaryFn V> struct ElemwiseOp<V> {
+  using Op = hfusion::ElemwiseBinaryOp;
+  using FnAttr = hfusion::BinaryFnAttr;
+  static constexpr hfusion::BinaryFn Fn = V;
+};
+
+template <linalg::UnaryFn V> struct ElemwiseOp<V> {
+  using Op = linalg::ElemwiseUnaryOp;
+  using FnAttr = linalg::UnaryFnAttr;
+  static constexpr linalg::UnaryFn Fn = V;
+};
+
+template <hfusion::UnaryFn V> struct ElemwiseOp<V> {
+  using Op = hfusion::ElemwiseUnaryOp;
+  using FnAttr = hfusion::UnaryFnAttr;
+  static constexpr hfusion::UnaryFn Fn = V;
+};
+
+
 /*****************************************************************************************
 ******************************************************************************************
 Functions for CodeGenTileLangNPUIRAPIA5 class
@@ -2317,7 +2345,7 @@ mlir::Value CodeGenTileLangNPUIRAPIA5::VisitExpr_(const CallNode *op) {
   } else if (op->op.same_as(Op::Get("tl.npuir_mul"))) {
     CreateHIVMBinaryVectorOp<mlir::hivm::VMulOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_sub"))) {
-    CreateHIVMBinaryVectorOp<mlir::hivm::VSubOp>(op);
+    CreateHIVMBinaryVectorOp<ElemwiseOp<linalg::BinaryFn::sub>>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_max"))) {
     CreateHIVMBinaryVectorOp<mlir::hivm::VMaxOp>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_min"))) {

--- a/src/target/codegen_npuir_api_a5.cc
+++ b/src/target/codegen_npuir_api_a5.cc
@@ -1838,13 +1838,19 @@ void CodeGenTileLangNPUIRAPIA5::CreateHIVMBinaryVectorOp(const CallNode *op) {
                                           op->args[3].as<Bool>().value());
     builder.create<T>(loc, mlir::TypeRange{}, mlir::ValueRange{src0, src1},
                       mlir::ValueRange{dst}, round_attr, transpose, broadcast);
-  } else if constexpr (std::is_same_v<T, mlir::hivm::VDivOp>) {
+  }} else if constexpr (std::is_same_v<T, mlir::hivm::VDivOp>) {
         builder.create<T>(loc, mlir::TypeRange{}, mlir::ValueRange{src0, src1},
                       mlir::ValueRange{dst}, true, transpose, broadcast);
+  } else if constexpr (is_elemwise_op<T>::value) {
+    auto fn_attr = T::FnAttr::get(builder.getContext(), T::Fn);
+    builder.create<typename T::Op>(loc, mlir::TypeRange{},
+                                    mlir::ValueRange{src0, src1},
+                                    mlir::ValueRange{dst}, fn_attr);
   } else {
     builder.create<T>(loc, mlir::TypeRange{}, mlir::ValueRange{src0, src1},
                       mlir::ValueRange{dst}, transpose, broadcast);
   }
+}
 }
 
 template <typename T>

--- a/src/target/codegen_npuir_api_a5.cc
+++ b/src/target/codegen_npuir_api_a5.cc
@@ -292,6 +292,8 @@ namespace {
 }  // namespace
 
 
+
+
 template <auto V> struct ElemwiseOp;
 
 template <linalg::BinaryFn V> struct ElemwiseOp<V> {
@@ -317,6 +319,13 @@ template <hfusion::UnaryFn V> struct ElemwiseOp<V> {
   using FnAttr = hfusion::UnaryFnAttr;
   static constexpr hfusion::UnaryFn Fn = V;
 };
+
+
+template <typename T>
+struct is_elemwise_op : std::false_type {};
+
+template <auto V>
+struct is_elemwise_op<ElemwiseOp<V>> : std::true_type {};
 
 
 /*****************************************************************************************


### PR DESCRIPTION
This PR changes the lowering of tl.npuir_sub in src/target/codegen_npuir_api_a5.cc from the hivm dialect (hivm::VSubOp) to the linalg dialect (linalg::ElemwiseBinaryOp with BinaryFn::sub), matching the equivalent change already made for dev mode in codegen_npuir_dev_a5.cc.