### PR TITLE
Pow op for A5 expert mode

### DIFF
--- a/src/target/codegen_npuir_api_a5.cc
+++ b/src/target/codegen_npuir_api_a5.cc
@@ -1839,6 +1839,119 @@ void CodeGenTileLangNPUIRAPIA5::VreduceCodegen(const CallNode *op) {
   matOp.setWritable(true);
 }
 
+// Expert memref pow must use tensor SSA so HFusion NormalizePowf can rewrite
+// f16/f32 (memref powf expands to illegal vector fpow on A5).
+void CodeGenTileLangNPUIRAPIA5::VpowCodegen(const CallNode *op) {
+  const CallNode *region_node_dst = op->args[2].as<CallNode>();
+  ICHECK(region_node_dst) << "npuir_pow destination must be a region";
+  const BufferLoadNode *buffer_load_node_dst =
+      region_node_dst->args[0].as<BufferLoadNode>();
+  ICHECK(buffer_load_node_dst)
+      << "npuir_pow destination region must wrap a BufferLoad";
+  DataType dst_dtype = buffer_load_node_dst->buffer->dtype;
+
+  auto processImm = [&](mlir::Value &src, int arg_id,
+                        Array<PrimExpr> &buffer_shape) {
+    if (op->args[arg_id].as<IntImm>() || op->args[arg_id].as<FloatImm>() ||
+        op->args[arg_id].as<tir::VarNode>()) {
+      const CallNode *region_node = op->args[1 - arg_id].as<CallNode>();
+      DataType target_dtype = dst_dtype;
+      if (region_node) {
+        if (const auto *buffer_load_node =
+                region_node->args[0].as<BufferLoadNode>()) {
+          target_dtype = buffer_load_node->buffer->dtype;
+        }
+      }
+      if (op->args[arg_id]->dtype != target_dtype) {
+        src = ScalarConvertType(op->args[arg_id], target_dtype);
+      } else {
+        src = MakeValue(op->args[arg_id]);
+      }
+    } else {
+      const CallNode *region_node = op->args[arg_id].as<CallNode>();
+      ICHECK(region_node) << "npuir_pow operand must be a scalar or region";
+      auto buffer_node = region_node->args[0].as<BufferLoadNode>();
+      buffer_shape = buffer_node->buffer->shape;
+      bool is_scalar_load = true;
+      for (int i = 0; i < buffer_shape.size(); i++) {
+        const IntImmNode *int_imm = region_node->args[2 + i].as<IntImmNode>();
+        if (!int_imm || int_imm->value != 1) {
+          is_scalar_load = false;
+          break;
+        }
+      }
+      if (is_scalar_load && arg_id == 1) {
+        src = GenMemrefLoadFromRegion(buffer_node);
+        buffer_shape.clear();
+      } else {
+        src = GenSubviewFromRegion(region_node);
+      }
+    }
+  };
+
+  mlir::Value src0, src1;
+  Array<PrimExpr> buffer_shape0, buffer_shape1;
+  processImm(src0, 0, buffer_shape0);
+  processImm(src1, 1, buffer_shape1);
+  mlir::Value dst = GenSubviewFromRegion(region_node_dst);
+
+  ArrayRef<int64_t> shape;
+  if (auto shapedType = dst.getType().dyn_cast<ShapedType>()) {
+    shape = shapedType.getShape();
+  }
+  auto dims0 = getBroadcastDim(buffer_shape0, shape);
+  auto dims1 = getBroadcastDim(buffer_shape1, shape);
+
+  auto loc = builder.getUnknownLoc();
+  MaybeBroadcastBinaryOperand(builder, loc, src0, dst, dims0);
+  MaybeBroadcastBinaryOperand(builder, loc, src1, dst, dims1);
+
+  auto dstMemTy = dst.getType().cast<mlir::MemRefType>();
+  auto elemTy = dstMemTy.getElementType();
+  auto dstShape = dstMemTy.getShape();
+
+  llvm::SmallVector<mlir::Value> dynamicSizes;
+  for (int64_t i = 0; i < dstMemTy.getRank(); ++i) {
+    if (dstMemTy.isDynamicDim(i)) {
+      dynamicSizes.push_back(builder.create<mlir::memref::DimOp>(loc, dst, i));
+    }
+  }
+
+  auto toTensorOperand = [&](mlir::Value v) -> mlir::Value {
+    if (v.getType().isa<mlir::MemRefType>()) {
+      mlir::Value contig = ensureDefaultSpaceContiguousMemref(builder, loc, v);
+      return toTensorValue(builder, loc, contig);
+    }
+    auto empty = builder.create<mlir::tensor::EmptyOp>(loc, dstShape, elemTy,
+                                                       dynamicSizes);
+    return builder
+        .create<mlir::linalg::FillOp>(loc, mlir::ValueRange{v},
+                                      mlir::ValueRange{empty})
+        .getResult(0);
+  };
+
+  mlir::Value t0 = toTensorOperand(src0);
+  mlir::Value t1 = toTensorOperand(src1);
+  mlir::Value outInit = builder.create<mlir::tensor::EmptyOp>(
+      loc, dstShape, elemTy, dynamicSizes);
+
+  hfusion::BinaryFn fn = elemTy.isa<mlir::FloatType>()
+                             ? hfusion::BinaryFn::powf
+                             : hfusion::BinaryFn::powi;
+  mlir::Value result =
+      builder
+          .create<hfusion::ElemwiseBinaryOp>(
+              loc, outInit.getType(), mlir::ValueRange{t0, t1},
+              mlir::ValueRange{outInit},
+              mlir::ArrayRef{builder.getNamedAttr(
+                  "fun", builder.getAttr<hfusion::BinaryFnAttr>(fn))})
+          .getResult(0);
+
+  auto matOp = builder.create<mlir::bufferization::MaterializeInDestinationOp>(
+      loc, result, dst);
+  matOp.setWritable(true);
+}
+
 void CodeGenTileLangNPUIRAPIA5::VcosCodegen(const CallNode *op) {
   tvm::tl::NpuirVCos npuirop(op->args, this->vmap);
   auto loc = builder.getUnknownLoc();
@@ -2991,8 +3104,7 @@ mlir::Value CodeGenTileLangNPUIRAPIA5::VisitExpr_(const CallNode *op) {
   } else if (op->op.same_as(Op::Get("tl.npuir_xor"))) {
     CreateHIVMBinaryVectorOp<ElemwiseOp<hfusion::BinaryFn::vxor>>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_pow"))) {
-    CreateHIVMBinaryVectorOp<ElemwiseOp<hfusion::BinaryFn::powf>,
-                             ElemwiseOp<hfusion::BinaryFn::powi>>(op);
+    VpowCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_shl"))) {
     CreateHIVMBinaryVectorOp<void, ElemwiseOp<hfusion::BinaryFn::shli>>(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_shr"))) {

--- a/src/target/codegen_npuir_api_a5.h
+++ b/src/target/codegen_npuir_api_a5.h
@@ -230,6 +230,7 @@ private:
   void VbrcCodegen(const CallNode *op);
   void VcastCodegen(const CallNode *op);
   void VreduceCodegen(const CallNode *op);
+  void VpowCodegen(const CallNode *op);
   void VsigmoidCodegen(const CallNode *op);
   void VcosCodegen(const CallNode *op);
   void VsinCodegen(const CallNode *op);

--- a/unittest/npuir/mlir_files/vec_pow_2d.mlir
+++ b/unittest/npuir/mlir_files/vec_pow_2d.mlir
@@ -1,0 +1,40 @@
+module attributes {hivm.module_core_type = #hivm.module_core_type<AIV>, memref.memref_as_ptr} {
+  func.func @main(%arg0: i64 {hacc.arg_type = #hacc.arg_type<ffts_base_address>}, %arg1: memref<?xi8>, %arg2: memref<?xi8>, %arg3: memref<?xf16, #hivm.address_space<gm>>, %arg4: memref<?xf16, #hivm.address_space<gm>>, %arg5: memref<?xf16, #hivm.address_space<gm>>, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32) attributes {SyncBlockLockArgIdx = 0 : i64, WorkspaceArgIdx = 1 : i64, hacc.entry, hacc.function_kind = #hacc.function_kind<DEVICE>, hivm.func_core_type = #hivm.func_core_type<AIV>, mix_mode = "aiv"} {
+    %c128 = arith.constant 128 : index
+    %c1 = arith.constant 1 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c2_i32 = arith.constant 2 : i32
+    hivm.hir.set_ffts_base_addr %arg0
+    %reinterpret_cast = memref.reinterpret_cast %arg3 to offset: [0], sizes: [128, 128], strides: [%c128, %c1] : memref<?xf16, #hivm.address_space<gm>> to memref<128x128xf16, strided<[128, 1]>, #hivm.address_space<gm>>
+    %reinterpret_cast_0 = memref.reinterpret_cast %arg5 to offset: [0], sizes: [128, 128], strides: [%c128, %c1] : memref<?xf16, #hivm.address_space<gm>> to memref<128x128xf16, strided<[128, 1]>, #hivm.address_space<gm>>
+    %reinterpret_cast_1 = memref.reinterpret_cast %arg4 to offset: [0], sizes: [128, 128], strides: [%c128, %c1] : memref<?xf16, #hivm.address_space<gm>> to memref<128x128xf16, strided<[128, 1]>, #hivm.address_space<gm>>
+    %0 = hivm.hir.get_block_idx -> i64
+    %1 = arith.trunci %0 : i64 to i32
+    %alloc = memref.alloc() : memref<32x64xf16, #hivm.address_space<ub>>
+    %alloc_2 = memref.alloc() : memref<32x64xf16, #hivm.address_space<ub>>
+    %alloc_3 = memref.alloc() : memref<32x64xf16, #hivm.address_space<ub>>
+    %2 = arith.divsi %1, %c2_i32 : i32
+    %3 = arith.muli %2, %c32_i32 : i32
+    %4 = arith.index_cast %3 : i32 to index
+    %5 = arith.remsi %1, %c2_i32 : i32
+    %6 = arith.muli %5, %c64_i32 : i32
+    %7 = arith.index_cast %6 : i32 to index
+    %subview = memref.subview %reinterpret_cast[%4, %7] [32, 64] [1, 1] : memref<128x128xf16, strided<[128, 1]>, #hivm.address_space<gm>> to memref<32x64xf16, strided<[128, 1], offset: ?>, #hivm.address_space<gm>>
+    memref.copy %subview, %alloc : memref<32x64xf16, strided<[128, 1], offset: ?>, #hivm.address_space<gm>> to memref<32x64xf16, #hivm.address_space<ub>>
+    %subview_4 = memref.subview %reinterpret_cast_1[%4, %7] [32, 64] [1, 1] : memref<128x128xf16, strided<[128, 1]>, #hivm.address_space<gm>> to memref<32x64xf16, strided<[128, 1], offset: ?>, #hivm.address_space<gm>>
+    memref.copy %subview_4, %alloc_2 : memref<32x64xf16, strided<[128, 1], offset: ?>, #hivm.address_space<gm>> to memref<32x64xf16, #hivm.address_space<ub>>
+    %alloc_5 = memref.alloc() : memref<32x64xf16>
+    memref.copy %alloc, %alloc_5 : memref<32x64xf16, #hivm.address_space<ub>> to memref<32x64xf16>
+    %8 = bufferization.to_tensor %alloc_5 restrict : memref<32x64xf16>
+    %alloc_6 = memref.alloc() : memref<32x64xf16>
+    memref.copy %alloc_2, %alloc_6 : memref<32x64xf16, #hivm.address_space<ub>> to memref<32x64xf16>
+    %9 = bufferization.to_tensor %alloc_6 restrict : memref<32x64xf16>
+    %10 = tensor.empty() : tensor<32x64xf16>
+    %11 = hfusion.elemwise_binary {fun = #hfusion.binary_fn<powf>} ins(%8, %9 : tensor<32x64xf16>, tensor<32x64xf16>) outs(%10 : tensor<32x64xf16>) -> tensor<32x64xf16>
+    bufferization.materialize_in_destination %11 in writable %alloc_3 : (tensor<32x64xf16>, memref<32x64xf16, #hivm.address_space<ub>>) -> ()
+    %subview_7 = memref.subview %reinterpret_cast_0[%4, %7] [32, 64] [1, 1] : memref<128x128xf16, strided<[128, 1]>, #hivm.address_space<gm>> to memref<32x64xf16, strided<[128, 1], offset: ?>, #hivm.address_space<gm>>
+    memref.copy %alloc_3, %subview_7 : memref<32x64xf16, #hivm.address_space<ub>> to memref<32x64xf16, strided<[128, 1], offset: ?>, #hivm.address_space<gm>>
+    return
+  }
+}

--- a/unittest/npuir/test_vec_pow_2d.py
+++ b/unittest/npuir/test_vec_pow_2d.py
@@ -1,0 +1,69 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+import os
+import filecmp
+
+import tilelang
+import tilelang.language as T
+
+tilelang.cache.clear_cache()
+
+M = 128
+N = 128
+K = 128
+
+
+def vec_pow(M, N, K, block_M, block_N, dtype="float16"):
+    m_num = M // block_M
+    n_num = N // block_N
+
+    BLOCK_SIZE = 20
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            A_VEC = T.alloc_ub((block_M, block_N), dtype)
+            B_VEC = T.alloc_ub((block_M, block_N), dtype)
+            C_VEC = T.alloc_ub((block_M, block_N), dtype)
+            for i in T.serial(T.ceildiv(m_num * n_num, BLOCK_SIZE)):
+                block_id = i * BLOCK_SIZE + cid
+                block_id_m = block_id // n_num
+                block_id_n = block_id % n_num
+                bx = block_id_m * block_M
+                by = block_id_n * block_N
+                T.copy(A[bx, by], A_VEC)
+                T.copy(B[bx, by], B_VEC)
+                T.npuir_pow(A_VEC, B_VEC, C_VEC)
+                T.copy(C_VEC, C[bx, by])
+
+    return main
+
+
+def test_vec_pow():
+    os.environ["TILELANG_ASCEND_MODE"] = "Expert"
+    func = vec_pow(M, N, K, 32, 64)
+    kernel = tilelang.engine.lower(func, target="npuir")
+
+    curr_name = os.path.splitext(os.path.basename(__file__))[0][5:] + ".mlir"
+    output_file = "./output/" + curr_name
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    with open(output_file, "w") as f:
+        f.write(kernel)
+
+    ref_file = "./mlir_files/" + curr_name
+    if os.environ.get("UPDATE_REF") == "1":
+        import shutil
+
+        shutil.copyfile(output_file, ref_file)
+        return
+
+    are_identical = filecmp.cmp(output_file, ref_file, shallow=False)
+    assert are_identical, f"'{output_file}' and '{ref_file}' are not identical"
+
+
+if __name__ == "__main__":
+    test_vec_pow()


### PR DESCRIPTION
1. Add A5 Expert-mode lowering for `tl.npuir_pow` via `VpowCodegen`, keeping hfusion.elemwise_binary (powf / powi) instead of hivm.hir.vpow.
2. Lower through tensor SSA `(to_tensor → hfusion pow → materialize_in_destination)` so HFusion NormalizePowf can rewrite the op; direct memref powf was expanding to illegal A5 v128f16 = fpow.
3. Add Expert unit test `test_vec_pow_2d.py` (float16)