### PR TITLE
[AscendNPU-IR] Support T.vsort

### DIFF
--- a/docs/Tilelang.language/排序操作/T.vsort.md
+++ b/docs/Tilelang.language/排序操作/T.vsort.md
@@ -1,0 +1,117 @@
+# Tilelang.language.vsort
+
+## 1. OP概述
+
+简介：`tilelang.language.vsort` 该算子对输入张量 `src` 沿指定轴 `sort_axis` 进行**排序（sort）**操作，同时输出排序后的值张量 `dst_value` 与对应的原始下标张量 `dst_index`。
+
+```python
+T.vsort(src, dst_value, dst_index, descending=False, sort_axis=-1)
+```
+
+## 2. OP规格
+
+### 2.1 参数说明
+
+| 参数名 | 类型 | 说明 |
+| ----------- | -------------- | ------------ |
+| `src` | `tensor` | 输入tensor，待排序数据 |
+| `dst_value` | `tensor` | 输出tensor，排序后的值，dtype 与 `src` 相同 |
+| `dst_index` | `tensor` | 输出tensor，排序后值对应的原始下标，dtype 为 int32 |
+| `descending` | `bool` | (可选) 排序顺序，`False`=升序（默认），`True`=降序 |
+| `sort_axis` | `int` | (可选) 排序轴，`-1`=尾轴（默认）。目前硬件仅支持尾轴排序 |
+
+### 2.2 支持规格
+
+#### 2.2.1 DataType支持
+
+| | uint8 | int8 | int16 | int32 | int64 | fp16 | fp32 | bf16 | bool |
+| -------- | ------- | ------ | ------ | ------- | ------- | ------ | ------ | ------ | ----------- |
+| Ascend | × | × | × | × | × | √ | √ | × | × |
+
+> `dst_index` 固定使用 int32。
+
+#### 2.2.2 Shape支持
+
+结论：输入 `src` 与输出 `dst_value`、`dst_index` 的 shape 必须完全一致（同 rank、同各维大小）。
+
+### 2.3 特殊限制说明
+
+1. **仅支持尾轴排序**：`sort_axis` 只能取 `-1` 或最后一维索引。非尾轴排序将在编译期报错。
+2. **元素类型限制**：`src` 和 `dst_value` 仅支持 fp16/fp32；不支持 bf16（如需 bf16 请先 vcast 到 fp32）。
+3. **下标类型**：`dst_index` 必须为 int32。
+4. **重复元素**：当存在重复值时，排序后下标可能与 PyTorch `torch.sort` 的结果不完全一致（排序稳定性差异）。验证时按「值匹配 + 下标指向的值匹配」双重校验。
+
+### 2.4 使用方法
+
+示例：实现了对尾轴的升序排序（Developer 模式）
+
+```python
+@T.prim_func
+def vsort_kernel(
+    src: T.Tensor((M, N), dtype),
+    dst_value: T.Tensor((M, N), dtype),
+    dst_index: T.Tensor((M, N), "int32"),
+):
+    with T.Kernel(1, is_npu=True) as (cid, _):
+        # Allocate UB memory (Developer 模式用 alloc_shared，Expert 模式用 alloc_ub)
+        src_ub = T.alloc_shared((M, N), dtype)
+        val_ub = T.alloc_shared((M, N), dtype)
+        idx_ub = T.alloc_shared((M, N), "int32")
+
+        # Copy data from GM to UB
+        T.copy(src, src_ub)
+
+        # Perform sort
+        T.vsort(src_ub, val_ub, idx_ub, descending=False, sort_axis=-1)
+
+        # Copy results back to GM
+        T.copy(val_ub, dst_value)
+        T.copy(idx_ub, dst_index)
+```
+
+Expert 模式示例：
+
+```python
+@T.prim_func
+def vsort_kernel_exp(
+    src: T.Tensor((M, N), dtype),
+    dst_value: T.Tensor((M, N), dtype),
+    dst_index: T.Tensor((M, N), "int32"),
+):
+    with T.Kernel(1, is_npu=True) as (cid, _):
+        src_ub = T.alloc_ub((M, N), dtype)
+        val_ub = T.alloc_ub((M, N), dtype)
+        idx_ub = T.alloc_ub((M, N), "int32")
+
+        T.copy(src, src_ub)
+        T.vsort(src_ub, val_ub, idx_ub, descending=False, sort_axis=-1)
+        T.copy(val_ub, dst_value)
+        T.copy(idx_ub, dst_index)
+```
+
+### 2.5 Golden 参考
+
+```python
+import torch
+
+def golden_vsort(src, descending=False):
+    values, indices = torch.sort(src, dim=-1, descending=descending)
+    return values, indices.to(torch.int32)
+```
+
+## 3. Tilelang Op到Ascend NPU IR Op的转换
+
+**tilelang::npuir_sort** 将被转换为 `hivm::VSortOp`（即 MLIR 中的 `hivm.hir.vsort`）。
+
+生成的 MLIR 形态：
+
+```mlir
+hivm.hir.vsort ins(%src : memref<...>) outs(%dst_value, %dst_index : memref<...>, memref<...>) descending = false sort_axis = -1
+```
+
+底层 VSortOp 定义位于 `3rdparty/AscendNPU-IR/bishengir/include/bishengir/Dialect/HIVM/IR/HIVMVectorOps.td`。
+
+## 4. 兼容性
+
+- `T.npuir_sort` 为兼容别名，与 `T.vsort` 完全等价。
+- 遵循 v 前缀 API 规范，新代码推荐使用 `T.vsort`。

--- a/src/op/ascend.cc
+++ b/src/op/ascend.cc
@@ -341,6 +341,26 @@ NpuirCumsum::NpuirCumsum(Array<PrimExpr> args, BufferMap vmap) {
   reverse = args[3].as<Bool>().value();
 }
 
+NpuirSort::NpuirSort(Array<PrimExpr> args, BufferMap vmap) {
+  Array<Range> rgs[3];
+  Buffer bf[3];
+  for (int i = 0; i < 3; i++) {
+    auto expr = args[i];
+    auto call = expr.as<CallNode>();
+    ICHECK(call);
+    auto region = RegionOp(call->args, vmap);
+    rgs[i] = region.GetRanges();
+    bf[i] = region.GetBuffer();
+  }
+  std::tie(this->src, this->dst_value, this->dst_index) =
+      std::tie(bf[0], bf[1], bf[2]);
+  std::tie(this->src_range, this->dst_value_range, this->dst_index_range) =
+      std::tie(rgs[0], rgs[1], rgs[2]);
+
+  descending = args[3].as<Bool>().value();
+  sort_axis = args[4].as<IntImmNode>()->value;
+}
+
 NpuirAtomicAdd::NpuirAtomicAdd(Array<PrimExpr> args, BufferMap vmap) {
   Array<Range> rgs[2];
   Buffer bf[2];
@@ -774,6 +794,11 @@ TIR_REGISTER_TL_OP(NpuirReduce, npuir_reduce)
 
 TIR_REGISTER_TL_OP(NpuirCumsum, npuir_cumsum)
     .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_REGISTER_TL_OP(NpuirSort, npuir_sort)
+    .set_num_inputs(5)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/op/ascend.h
+++ b/src/op/ascend.h
@@ -347,6 +347,21 @@ public:
   Array<Range> src_range, dst_range;
 };
 
+/// HIVM vector sort operation.
+/// Sort the sorting axis of src, output sorted values and original indices.
+class NpuirSort : public Operator {
+public:
+  NpuirSort(Array<PrimExpr> args, BufferMap vmap);
+
+  static const Op &Get();
+
+  Buffer src, dst_value, dst_index;
+  bool descending;
+  int64_t sort_axis;
+
+  Array<Range> src_range, dst_value_range, dst_index_range;
+};
+
 class NpuirAtomicAdd : public Operator {
 public:
   NpuirAtomicAdd(Array<PrimExpr> args, BufferMap vmap);

--- a/src/target/codegen_npuir.cc
+++ b/src/target/codegen_npuir.cc
@@ -787,6 +787,33 @@ void CodeGenTileLangNPUIR::VcmpCodegen(const CallNode *op, std::ostream &os) {
                << op->args[3].as<StringImm>().value()->value << ">\n";
 }
 
+void CodeGenTileLangNPUIR::VsortCodegen(const CallNode *op, std::ostream &os) {
+  /// Generate hivm.hir.vsort for tl.npuir_sort.
+  /// before:
+  ///   T.npuir_sort(src, dst_value, dst_index, descending, sort_axis)
+  /// after:
+  ///   hivm.hir.vsort ins(%src : <type>) outs(%dst_value, %dst_index : <t>,
+  ///   <t>)
+  ///     descending = false sort_axis = -1
+  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
+  String src_data_name = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
+  String dst_value_name =
+      GenSubviewFromRegion(npuirop.dst_value, npuirop.dst_value_range);
+  String dst_index_name =
+      GenSubviewFromRegion(npuirop.dst_index, npuirop.dst_index_range);
+
+  this->PrintIndent();
+  this->stream << "hivm.hir.vsort";
+  this->stream << " ins(%" << src_data_name << " : "
+               << GetMemrefInfo(src_data_name) << ")";
+  this->stream << " outs(%" << dst_value_name << ", %" << dst_index_name
+               << " : " << GetMemrefInfo(dst_value_name) << ", "
+               << GetMemrefInfo(dst_index_name) << ")";
+  this->stream << " descending = " << (npuirop.descending ? "true" : "false");
+  this->stream << " sort_axis = " << npuirop.sort_axis;
+  this->stream << "\n";
+}
+
 void CodeGenTileLangNPUIR::VbrcCodegen(const CallNode *op, std::ostream &os) {
   // Generate hivm.hir.vbrc for tl.npuir_vbrc.
   tvm::tl::NpuirBrc npuirop(op->args, this->vmap);
@@ -1243,6 +1270,8 @@ void CodeGenTileLangNPUIR::VisitExpr_(const CallNode *op, std::ostream &os) {
     UnaryVecOpCodegen<tvm::tl::NpuirRelu>(op, os);
   } else if (op->op.same_as(Op::Get("tl.npuir_select"))) {
     VselectCodegen(op, os);
+  } else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
+    VsortCodegen(op, os);
   } else if (op->op.same_as(Op::Get("tl.npuir_cmp"))) {
     VcmpCodegen(op, os);
   } else if (op->op.same_as(Op::Get("tl.npuir_load_nd2nz"))) {

--- a/src/target/codegen_npuir.h
+++ b/src/target/codegen_npuir.h
@@ -134,6 +134,7 @@ private:
   void VcastCodegen(const CallNode *op, std::ostream &os);
   void VcmpCodegen(const CallNode *op, std::ostream &os);
   void VselectCodegen(const CallNode *op, std::ostream &os);
+  void VsortCodegen(const CallNode *op, std::ostream &os);
   void VreduceCodegen(const CallNode *op, std::ostream &os);
   void FixpipeCodegen(const CallNode *op, std::ostream &os);
   void DotCodegen(const CallNode *op, std::ostream &os);

--- a/src/target/codegen_npuir_api.cc
+++ b/src/target/codegen_npuir_api.cc
@@ -1595,6 +1595,25 @@ void CodeGenTileLangNPUIRAPI::VcumsumCodegen(const CallNode *op) {
       builder.getDenseI64ArrayAttr(npuirop.cum_dims));
 }
 
+void CodeGenTileLangNPUIRAPI::VsortCodegen(const CallNode *op) {
+  /// Generate hivm.hir.vsort for tl.npuir_sort.
+  /// before:
+  ///   T.npuir_sort(src, dst_value, dst_index, descending, sort_axis)
+  /// after:
+  ///   hivm.hir.vsort ins(src) outs(dst_value, dst_index)
+  ///     descending = false sort_axis = -1
+  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
+  mlir::Location loc = builder.getUnknownLoc();
+  Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
+  Value dst_value =
+      GenSubviewFromRegion(npuirop.dst_value, npuirop.dst_value_range);
+  Value dst_index =
+      GenSubviewFromRegion(npuirop.dst_index, npuirop.dst_index_range);
+  builder.create<mlir::hivm::VSortOp>(loc, TypeRange{}, src,
+                                      mlir::ValueRange{dst_value, dst_index},
+                                      npuirop.descending, npuirop.sort_axis);
+}
+
 void CodeGenTileLangNPUIRAPI::VsigmoidCodegen(const tvm::tir::CallNode *op) {
   tvm::tl::NpuirSigmoid npuirop(op->args, this->vmap);
   Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
@@ -2660,6 +2679,8 @@ mlir::Value CodeGenTileLangNPUIRAPI::VisitExpr_(const CallNode *op) {
     VsigmoidCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_cumsum"))) {
     VcumsumCodegen(op);
+  } else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
+    VsortCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_atomic_add"))) {
     VAtomicAddCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_gather"))) {

--- a/src/target/codegen_npuir_api.h
+++ b/src/target/codegen_npuir_api.h
@@ -232,6 +232,7 @@ private:
   void VreduceCodegen(const CallNode *op);
   void VsigmoidCodegen(const CallNode *op);
   void VcumsumCodegen(const CallNode *op);
+  void VsortCodegen(const CallNode *op);
   void VAtomicAddCodegen(const CallNode *op);
   void VgatherCodegen(const CallNode *op);
   void VtransposeCodegen(const CallNode *op);

--- a/src/target/codegen_npuir_api_a5.cc
+++ b/src/target/codegen_npuir_api_a5.cc
@@ -2318,6 +2318,20 @@ void CodeGenTileLangNPUIRAPIA5::VcumsumCodegen(const CallNode *op) {
       builder.getDenseI64ArrayAttr(npuirop.cum_dims), false);
 }
 
+void CodeGenTileLangNPUIRAPIA5::VsortCodegen(const CallNode *op) {
+  /// Generate hivm.hir.vsort for tl.npuir_sort.
+  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
+  mlir::Location loc = builder.getUnknownLoc();
+  Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
+  Value dst_value =
+      GenSubviewFromRegion(npuirop.dst_value, npuirop.dst_value_range);
+  Value dst_index =
+      GenSubviewFromRegion(npuirop.dst_index, npuirop.dst_index_range);
+  builder.create<mlir::hivm::VSortOp>(loc, TypeRange{}, src,
+                                      mlir::ValueRange{dst_value, dst_index},
+                                      npuirop.descending, npuirop.sort_axis);
+}
+
 void CodeGenTileLangNPUIRAPIA5::VsigmoidCodegen(const tvm::tir::CallNode *op) {
   tvm::tl::NpuirSigmoid npuirop(op->args, this->vmap);
   Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
@@ -3156,6 +3170,8 @@ mlir::Value CodeGenTileLangNPUIRAPIA5::VisitExpr_(const CallNode *op) {
     VsigmoidCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_cumsum"))) {
     VcumsumCodegen(op);
+  } else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
+    VsortCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_atomic_add"))) {
     VAtomicAddCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_gather"))) {

--- a/src/target/codegen_npuir_api_a5.h
+++ b/src/target/codegen_npuir_api_a5.h
@@ -237,6 +237,7 @@ private:
   void VerfCodegen(const CallNode *op);
   void VtanhCodegen(const CallNode *op);
   void VcumsumCodegen(const CallNode *op);
+  void VsortCodegen(const CallNode *op);
   void VAtomicAddCodegen(const CallNode *op);
   void VgatherCodegen(const CallNode *op);
   void VtransposeCodegen(const CallNode *op);

--- a/src/target/codegen_npuir_dev.cc
+++ b/src/target/codegen_npuir_dev.cc
@@ -2363,6 +2363,23 @@ void CodeGenTileLangNPUIRDEV::VcumsumCodegen(const CallNode *op) {
   SetVarValue(npuirop.dst, newCumsumOp->getResult(0));
 }
 
+void CodeGenTileLangNPUIRDEV::VsortCodegen(const CallNode *op) {
+  /// Generate hivm.hir.vsort for tl.npuir_sort.
+  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
+  mlir::Location loc = builder.getUnknownLoc();
+  Value src = GetVarValue(npuirop.src);
+  Value dst_value = GetVarValue(npuirop.dst_value);
+  Value dst_index = GetVarValue(npuirop.dst_index);
+  mlir::Type val_type = dst_value.getType();
+  mlir::Type idx_type = dst_index.getType();
+  llvm::SmallVector<mlir::Type, 2> result_types({val_type, idx_type});
+  auto newSortOp = builder.create<mlir::hivm::VSortOp>(
+      loc, result_types, src, mlir::ValueRange{dst_value, dst_index},
+      npuirop.descending, npuirop.sort_axis);
+  SetVarValue(npuirop.dst_value, newSortOp->getResult(0));
+  SetVarValue(npuirop.dst_index, newSortOp->getResult(1));
+}
+
 void CodeGenTileLangNPUIRDEV::VsigmoidCodegen(const tvm::tir::CallNode *op) {
   tvm::tl::NpuirSigmoid npuirop(op->args, this->vmap);
   Value src = GetVarValue(npuirop.src);
@@ -3666,6 +3683,8 @@ mlir::Value CodeGenTileLangNPUIRDEV::VisitExpr_(const CallNode *op) {
     VAtomicAddCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_cumsum"))) {
     VcumsumCodegen(op);
+  } else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
+    VsortCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_gather"))) {
     VgatherCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_transpose"))) {

--- a/src/target/codegen_npuir_dev.h
+++ b/src/target/codegen_npuir_dev.h
@@ -246,6 +246,7 @@ private:
   void VcastCodegen(const CallNode *op);
   void VreduceCodegen(const CallNode *op);
   void VcumsumCodegen(const CallNode *op);
+  void VsortCodegen(const CallNode *op);
   void VAtomicAddCodegen(const CallNode *op);
   void VsigmoidCodegen(const CallNode *op);
   void VgatherCodegen(const CallNode *op);

--- a/src/target/codegen_npuir_dev_a5.cc
+++ b/src/target/codegen_npuir_dev_a5.cc
@@ -2820,6 +2820,25 @@ void CodeGenTileLangNPUIRDEVA5::VcumsumCodegen(const CallNode *op) {
   SetVarValue(npuirop.dst, newCumsumOp->getResult(0));
 }
 
+void CodeGenTileLangNPUIRDEVA5::VsortCodegen(const CallNode *op) {
+  /// Generate hivm.hir.vsort for tl.npuir_sort.
+  /// There is no hfusion::SortOp, so use hivm::VSortOp directly.
+  /// VSortOp accepts TensorOrMemref so GetVarValue (tensor) is valid.
+  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
+  mlir::Location loc = builder.getUnknownLoc();
+  Value src = GetVarValue(npuirop.src);
+  Value dst_value = GetVarValue(npuirop.dst_value);
+  Value dst_index = GetVarValue(npuirop.dst_index);
+  mlir::Type val_type = dst_value.getType();
+  mlir::Type idx_type = dst_index.getType();
+  mlir::TypeRange result_tensors({val_type, idx_type});
+  auto newSortOp = builder.create<mlir::hivm::VSortOp>(
+      loc, result_tensors, src, mlir::ValueRange{dst_value, dst_index},
+      npuirop.descending, npuirop.sort_axis);
+  SetVarValue(npuirop.dst_value, newSortOp->getResult(0));
+  SetVarValue(npuirop.dst_index, newSortOp->getResult(1));
+}
+
 void CodeGenTileLangNPUIRDEVA5::VsigmoidCodegen(const tvm::tir::CallNode *op) {
   tvm::tl::NpuirSigmoid npuirop(op->args, this->vmap);
   Value src = GetVarValue(npuirop.src);
@@ -4271,6 +4290,8 @@ mlir::Value CodeGenTileLangNPUIRDEVA5::VisitExpr_(const CallNode *op) {
     VAtomicAddCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_cumsum"))) {
     VcumsumCodegen(op);
+  } else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
+    VsortCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_gather"))) {
     VgatherCodegen(op);
   } else if (op->op.same_as(Op::Get("tl.npuir_indirect_load"))) {

--- a/src/target/codegen_npuir_dev_a5.h
+++ b/src/target/codegen_npuir_dev_a5.h
@@ -254,6 +254,7 @@ private:
   void VcastCodegen(const CallNode *op);
   void VreduceCodegen(const CallNode *op);
   void VcumsumCodegen(const CallNode *op);
+  void VsortCodegen(const CallNode *op);
   void VAtomicAddCodegen(const CallNode *op);
   void VsigmoidCodegen(const CallNode *op);
   void VgatherCodegen(const CallNode *op);

--- a/testing/npuir/sort_ops/test_vsort_dev.py
+++ b/testing/npuir/sort_ops/test_vsort_dev.py
@@ -1,0 +1,75 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("sort"),
+    pytest.mark.mode("Developer"),
+]
+
+DTYPES = ["float16", "float32"]
+
+
+def vsort_kernel(M, N, dtype, descending, sort_axis):
+    BLOCK_SIZE = 1
+
+    @T.prim_func
+    def vsortDev(
+        src: T.Tensor((M, N), dtype),
+        dst_value: T.Tensor((M, N), dtype),
+        dst_index: T.Tensor((M, N), "int32"),
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            src_ub = T.alloc_shared((M, N), dtype)
+            val_ub = T.alloc_shared((M, N), dtype)
+            idx_ub = T.alloc_shared((M, N), "int32")
+            T.copy(src, src_ub)
+            T.vsort(
+                src_ub,
+                val_ub,
+                idx_ub,
+                descending=descending,
+                sort_axis=sort_axis,
+            )
+            T.copy(val_ub, dst_value)
+            T.copy(idx_ub, dst_index)
+
+    return vsortDev
+
+
+def golden_sort(src, descending):
+    values, indices = torch.sort(src, dim=-1, descending=descending)
+    return values, indices.to(torch.int32)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("descending", [False, True])
+def test_vsort_dev(dtype, descending):
+    M, N = 4, 1024
+    sort_axis = -1
+    src = gen_tensor((M, N), dtype, kind="randn")
+    dst_value = gen_tensor((M, N), dtype, kind="zeros")
+    dst_index = gen_tensor((M, N), "int32", kind="zeros")
+
+    ref_value, ref_index = golden_sort(src.cpu(), descending=descending)
+
+    func = vsort_kernel(
+        M=M, N=N, dtype=dtype, descending=descending, sort_axis=sort_axis
+    )
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(src, dst_value, dst_index)
+
+    assert_close(dst_value.cpu(), ref_value, rtol=1e-3, atol=1e-3)
+    for r in range(M):
+        assert sorted(dst_index[r].cpu().tolist()) == list(range(N)), (
+            f"row {r} indices not a permutation of 0..{N - 1}"
+        )
+        assert torch.all(
+            src.cpu()[r].gather(0, dst_index[r].cpu().long()) == ref_value[r].cpu()
+        ), f"row {r} index-value mismatch"

--- a/testing/npuir/sort_ops/test_vsort_exp.py
+++ b/testing/npuir/sort_ops/test_vsort_exp.py
@@ -1,0 +1,75 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025.
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+from testcommon import assert_close, gen_tensor
+
+pytestmark = [
+    pytest.mark.op("sort"),
+    pytest.mark.mode("Expert"),
+]
+
+DTYPES = ["float16", "float32"]
+
+
+def vsort_kernel_exp(M, N, dtype, descending, sort_axis):
+    BLOCK_SIZE = 1
+
+    @T.prim_func
+    def vsortExp(
+        src: T.Tensor((M, N), dtype),
+        dst_value: T.Tensor((M, N), dtype),
+        dst_index: T.Tensor((M, N), "int32"),
+    ):
+        with T.Kernel(BLOCK_SIZE, is_npu=True) as (cid, _):
+            src_ub = T.alloc_ub((M, N), dtype)
+            val_ub = T.alloc_ub((M, N), dtype)
+            idx_ub = T.alloc_ub((M, N), "int32")
+            T.copy(src, src_ub)
+            T.vsort(
+                src_ub,
+                val_ub,
+                idx_ub,
+                descending=descending,
+                sort_axis=sort_axis,
+            )
+            T.copy(val_ub, dst_value)
+            T.copy(idx_ub, dst_index)
+
+    return vsortExp
+
+
+def golden_sort(src, descending):
+    values, indices = torch.sort(src, dim=-1, descending=descending)
+    return values, indices.to(torch.int32)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("descending", [False, True])
+def test_vsort_exp(dtype, descending):
+    M, N = 4, 1024
+    sort_axis = -1
+    src = gen_tensor((M, N), dtype, kind="randn")
+    dst_value = gen_tensor((M, N), dtype, kind="zeros")
+    dst_index = gen_tensor((M, N), "int32", kind="zeros")
+
+    ref_value, ref_index = golden_sort(src.cpu(), descending=descending)
+
+    func = vsort_kernel_exp(
+        M=M, N=N, dtype=dtype, descending=descending, sort_axis=sort_axis
+    )
+    compiled = tilelang.compile(func, target="npuir")
+    compiled(src, dst_value, dst_index)
+
+    assert_close(dst_value.cpu(), ref_value, rtol=1e-3, atol=1e-3)
+    for r in range(M):
+        assert sorted(dst_index[r].cpu().tolist()) == list(range(N)), (
+            f"row {r} indices not a permutation of 0..{N - 1}"
+        )
+        assert torch.all(
+            src.cpu()[r].gather(0, dst_index[r].cpu().long()) == ref_value[r].cpu()
+        ), f"row {r} index-value mismatch"

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -130,6 +130,8 @@ from .customize_npuir import (
     reduce_absmax,  # noqa: F401, F811
     npuir_cumsum,  # noqa: F401
     npuir_cumsum as cumsum,  # noqa: F401, F811
+    npuir_sort,  # noqa: F401
+    npuir_sort as vsort,  # noqa: F401
     npuir_clamp,  # noqa: F401
     npuir_clamp as vclamp,  # noqa: F401
     npuir_atomic_add,  # noqa: F401

--- a/tilelang/language/customize_npuir.py
+++ b/tilelang/language/customize_npuir.py
@@ -1083,6 +1083,48 @@ def npuir_cumsum(
     )
 
 
+def npuir_sort(
+    src,
+    dst_value,
+    dst_index,
+    descending: bool = False,
+    sort_axis: int = -1,
+):
+    """Sort input along sort_axis, output sorted values and original indices.
+
+    Args:
+        src (Union[tir.Buffer, tir.BufferLoad, tir.BufferRegion]): Input tensor
+        dst_value (Union[tir.Buffer, tir.BufferLoad]): Output tensor storing
+            sorted values, same dtype as src.
+        dst_index (Union[tir.Buffer, tir.BufferLoad]): Output tensor storing
+            the original index corresponding to each sorted value (int32/int64).
+        descending (bool, optional): Sort order. False=ascending (default),
+            True=descending.
+        sort_axis (int, optional): Axis to sort. -1 = last axis (default).
+            Currently only the tail axis is supported by the hardware.
+
+    Returns:
+        tir.Call: The TIR call for the sort operation
+    """
+    src_extent = _get_extent(src)
+    val_extent = _get_extent(dst_value)
+    idx_extent = _get_extent(dst_index)
+
+    src_region = _to_region(src, "r", src_extent)
+    dst_value_region = _to_region(dst_value, "w", val_extent)
+    dst_index_region = _to_region(dst_index, "w", idx_extent)
+
+    return tir.call_intrin(
+        "handle",
+        tir.op.Op.get("tl.npuir_sort"),
+        src_region,
+        dst_value_region,
+        dst_index_region,
+        descending,
+        sort_axis,
+    )
+
+
 def npuir_clamp(
     src: tir.Buffer, dst: Optional[tir.Buffer], min_val: PrimExpr, max_val: PrimExpr
 ):


### PR DESCRIPTION
# T.vsort 原语设计文档

> 给 TileLang DSL 新增一个原语 `T.vsort`，并打通从前端到 Ascend NPU IR 后端代码生成的端到端链路。底层 HIVM dialect 的 `hivm.hir.vsort`（`VSortOp`）已存在于 `3rdparty/AscendNPU-IR`，本任务只负责在 TileLang 侧接入。

---

## 0. 背景与底层 IR 现状

### 0.1 功能概述

`vsort` 对输入向量沿指定轴排序，**同时输出排序后的值与该值在原始输入中的下标**。这是与 `vmax`/`vmin`/`vreduce` 不同的多输出原语。

### 0.2 底层 HIVM VSortOp 现状（已存在，无需新增）

文件：`3rdparty/AscendNPU-IR/bishengir/include/bishengir/Dialect/HIVM/IR/HIVMVectorOps.td:1693`

```tablegen
def VSortOp : HIVM_VectorOp<"vsort",
    [AttrSizedOperandSegments, OperElemTypeConstraints<[0,1],[F16,F32]>, ...]> {
  let arguments = (ins TensorOrMemref:$src,
                       Variadic<TensorOrMemref>:$dst,   // 2 个 dst: dst_value + dst_index
                       Optional<AnyMemRef>:$temp_buffer,
                       DefaultValuedOptionalAttr<BoolAttr, "false">:$descending,
                       DefaultValuedAttr<I64Attr, "-1">:$sort_axis);
  let builders = [
    OpBuilder<(ins "TypeRange":$result, "Value":$src,
                   "ValueRange":$dst, "bool":$descending, "int64_t":$sort_axis)>];
}
```

关键约束（来自 `.td` description）：
1. 输入与输出向量 rank 相同。
2. **目前只支持尾轴排序**（last axis）。
3. 元素类型仅 `F16` / `F32`。
4. 输出有 2 个：`dst_value`（同输入 dtype）+ `dst_index`（整数下标）。
5. 2 个属性：`descending: bool`（默认 false=升序）、`sort_axis: i64`（默认 -1=尾轴）。

C++ builder 调用形态：
```cpp
builder.create<mlir::hivm::VSortOp>(loc, TypeRange/*result*/, Value/*src*/,
                                    ValueRange/*{dst_value, dst_index}*/,
                                    bool/*descending*/, int64_t/*sort_axis*/);
```

### 0.3 TileLang 侧现状

当前 TileLang DSL（`tilelang/language`）没有 `vsort` / `npuir_sort`。需新增。

---

## 1. 概述

### 1.1 原语名称

`T.vsort`（兼容名 `T.npuir_sort`）

### 1.2 功能描述

沿指定轴对输入张量排序，输出排序后的值张量与对应原始下标张量。

### 1.3 数学公式

$$
\text{vsort}(X, \text{axis}, \text{descending}) \rightarrow (V, I)
$$
其中 $V$ 为 $X$ 沿 `axis` 排序后的值序列；$I_k$ 为 $V_k$ 在原始 $X_{\text{axis}}$ 中的下标。`descending=true` 时降序。

### 1.4 数据流图

```
GM[src] --T.copy--> UB[src_ub] --T.vsort--> UB[dst_value_ub], UB[dst_index_ub]
                                            --T.copy--> GM[dst_value], GM[dst_index]
```

---

## 2. 编程模式选型

### 2.1 模式结论

**Developer + Expert 双模式均支持**（与 `vexp`/`vcumsum` 一致：两个 MLIR builder 后端 `codegen_npuir_dev.cc`、`codegen_npuir_api.cc` 都要实现）。

### 2.2 选型理由

`vsort` 是纯 Vector 原语，输入输出均驻留在 UB，无需 Cube/L1/L0。Developer 模式（`codegen_npuir_dev.cc`）与 Expert 模式（`codegen_npuir_api.cc`）是 npuir 分支的两条主代码生成路径，新增原语必须两条路径同时接入，否则只在某个 mode 下可用。A5 变体（`*_a5.cc`）同样需要接入以保持硬件覆盖完整。

### 2.3 模式影响

| 维度 | 本原语的选择 |
|------|-------------|
| 内存分配 | `T.alloc_shared` / `T.alloc_fragment`（UB） |
| 计算方式 | 单个 `T.vsort` 调用，无循环 |
| 同步 | 自动同步（无跨核协作） |

---

## 3. API 映射设计

### 3.1 前端 API 设计

```python
def npuir_sort(
    src,
    dst_value,
    dst_index,
    descending: bool = False,
    sort_axis: int = -1,
):
    ...
    return tir.call_intrin(
        "handle",
        tir.op.Op.get("tl.npuir_sort"),
        src_region,        # args[0]
        dst_value_region,   # args[1]
        dst_index_region,   # args[2]
        descending,         # args[3]  Python bool -> tir.Bool/IntImm
        sort_axis,          # args[4]  Python int -> tir.IntImm
    )
```

公开导出：`npuir_sort as vsort`（v 前缀优先，符合 AGENTS.md API Convention）。

### 3.2 参数到 TIR args 的映射

| 前端参数 | TIR `op->args` 下标 | 类型 | 说明 |
|----------|--------------------|------|------|
| `src` | 0 | region call | 读区域 |
| `dst_value` | 1 | region call | 写区域，dtype 同 src |
| `dst_index` | 2 | region call | 写区域，整数 dtype（int32/int64） |
| `descending` | 3 | `tir.const(bool)` | 降序标志 |
| `sort_axis` | 4 | `tir.const(int)` | 排序轴，-1=尾轴 |

> 参考 `npuir_cumsum`（`customize_npuir.py:1042`）同样把标量 `dim`/`reverse` 作为 `op->args` 末尾传入，C++ 侧用 `as<Bool>()` / `as<IntImmNode>()` 解析。

### 3.3 计算伪代码（示例 kernel）

```python
@T.prim_func
def vsort_kernel(
    src: T.Tensor((M, N), dtype),
    dst_value: T.Tensor((M, N), dtype),
    dst_index: T.Tensor((M, N), "int32"),
):
    with T.Kernel(1, is_npu=True) as (cid, _):
        src_ub = T.alloc_shared((M, N), dtype)
        val_ub = T.alloc_fragment((M, N), dtype)
        idx_ub = T.alloc_fragment((M, N), "int32")
        T.copy(src, src_ub)
        T.vsort(src_ub, val_ub, idx_ub, descending=False, sort_axis=-1)
        T.copy(val_ub, dst_value)
        T.copy(idx_ub, dst_index)
```

### 3.4 API 可行性确认

- 底层 `mlir::hivm::VSortOp` 已存在（§0.2），builder 已定义。
- 所有 codegen 头文件已 `#include "bishengir/Dialect/HIVM/IR/HIVM.h"`，无需新增 include。
- 前端 `tir.call_intrin` + `tir.op.Op.get("tl.npuir_sort")` 模式与现有所有 npuir 原语一致。

---

## 4. 全链路实现设计（核心）

`vsort` 与 `vexp`（单入单出）不同，是 **1 入 2 出 + 2 标量属性**，因此不能复用 `UnaryVecOpCodegen<T,U>` 模板，需仿照 `VcumsumCodegen` / `VgatherCodegen` 写一个独立的 `VsortCodegen`。最贴近的参考是 **`vcumsum`**（同样带 bool + int 标量属性）和 **`vgather`**（同样多 buffer）。

### 4.1 实现层次总表

| # | 文件 | 改动 | 参考样板 |
|---|------|------|----------|
| 1 | `tilelang/language/customize_npuir.py` | 新增 `npuir_sort()` 函数 | `npuir_cumsum` (1042) |
| 2 | `tilelang/language/__init__.py` | 导出 `npuir_sort` / `npuir_sort as vsort` | 197 行附近 |
| 3 | `src/op/ascend.h` | 新增 `class NpuirSort : public Operator` | `NpuirCumsum` (337) |
| 4 | `src/op/ascend.cc` | 构造函数 + `TIR_REGISTER_TL_OP(NpuirSort, npuir_sort)` | `NpuirCumsum` (321, 775) |
| 5 | `3rdparty/.../HIVMVectorOps.td` | **不改**（VSortOp 已存在） | — |
| 6 | `src/target/codegen_npuir.cc` | 新增 `VsortCodegen` + dispatch | `VselectCodegen` (740) |
| 7 | `src/target/codegen_npuir_dev.cc` | 新增 `VsortCodegen` + dispatch + CheckVar | `VcumsumCodegen` (2342) |
| 8 | `src/target/codegen_npuir_api.cc` | 新增 `VsortCodegen` + dispatch | `VcumsumCodegen` (1578) |
| 9 | `src/target/codegen_npuir_dev_a5.cc` | 新增 `VsortCodegen` + dispatch | `VcumsumCodegen` (2798) |
| 10 | `src/target/codegen_npuir_api_a5.cc` | 新增 `VsortCodegen` + dispatch | `VcumsumCodegen` (2301) |
| 11 | `src/target/codegen_npuir_dev.h` / `api.h` / `dev_a5.h` / `api_a5.h` / `npuir.h` | 声明 `void VsortCodegen(...)` | `VcumsumCodegen` 声明 |
| 12 | `src/transform/npu_loop_vectorize.cc` | 可选：allowlist 加 `tl.npuir_sort` | 1282 行附近 |
| 13 | `src/transform/legalize_npuir_bf16.cc` | 可选：bf16 list 加 `tl.npuir_sort` | 84 行附近 |

> `tilelang/tladapter/` **无需改动**（只包通用 MLIR pass，不涉及原语 lowering）。

### 4.2 各层详细设计

#### 4.2.1 前端 DSL（层 1-2）

`customize_npuir.py` 新增（位置放在 `npuir_cumsum` 之后或文件末尾合理分组处）：

```python
def npuir_sort(src, dst_value, dst_index, descending: bool = False, sort_axis: int = -1):
    """Sort input along sort_axis, output sorted values and original indices.

    Args:
        src: Input tensor (Buffer/BufferLoad/BufferRegion).
        dst_value: Output tensor storing sorted values (same dtype as src).
        dst_index: Output tensor storing original indices (int32/int64).
        descending: False=ascending (default), True=descending.
        sort_axis: Axis to sort, -1 = last axis (hardware currently only supports last axis).

    Returns:
        tir.Call: The TIR call for the sort operation.
    """
    src_extent = _get_extent(src)
    val_extent = _get_extent(dst_value)
    idx_extent = _get_extent(dst_index)

    src_region = _to_region(src, "r", src_extent)
    dst_value_region = _to_region(dst_value, "w", val_extent)
    dst_index_region = _to_region(dst_index, "w", idx_extent)

    return tir.call_intrin(
        "handle",
        tir.op.Op.get("tl.npuir_sort"),
        src_region,
        dst_value_region,
        dst_index_region,
        descending,
        sort_axis,
    )
```

`__init__.py` 在 `from .customize_npuir import (...)` 块内（197 行前）加：
```python
    npuir_sort,  # noqa: F401
    npuir_sort as vsort,  # noqa: F401
```

#### 4.2.2 C++ op 类（层 3-4）

`src/op/ascend.h`（仿 `NpuirCumsum`，放在 `NpuirCumsum` 后）：
```cpp
class NpuirSort : public Operator {
public:
  NpuirSort(Array<PrimExpr> args, BufferMap vmap);
  static const Op &Get();

  Buffer src, dst_value, dst_index;
  bool descending;
  int64_t sort_axis;
  Array<Range> src_range, dst_value_range, dst_index_range;
};
```

`src/op/ascend.cc` 构造函数（仿 `NpuirCumsum::NpuirCumsum`，3 个 region + 2 标量）：
```cpp
NpuirSort::NpuirSort(Array<PrimExpr> args, BufferMap vmap) {
  Array<Range> rgs[3];
  Buffer bf[3];
  for (int i = 0; i < 3; i++) {
    auto expr = args[i];
    auto call = expr.as<CallNode>();
    ICHECK(call);
    auto region = RegionOp(call->args, vmap);
    rgs[i] = region.GetRanges();
    bf[i] = region.GetBuffer();
  }
  std::tie(this->src, this->dst_value, this->dst_index) =
      std::tie(bf[0], bf[1], bf[2]);
  std::tie(this->src_range, this->dst_value_range, this->dst_index_range) =
      std::tie(rgs[0], rgs[1], rgs[2]);

  descending = args[3].as<Bool>().value();          // 或 IntImm->value()!=0
  sort_axis = args[4].as<IntImmNode>()->value;     // i64
}

TIR_REGISTER_TL_OP(NpuirSort, npuir_sort)
    .set_num_inputs(5)
    .set_attr<TCallEffectKind>("TCallEffectKind",
                               Integer(CallEffectKind::kOpaque));
```

> 注意 `descending` 在前端以 Python `bool` 传入 `tir.call_intrin`，TVM 会包成 `tir.const`(`Bool`)。C++ 侧优先 `args[3].as<Bool>()`；若不可靠则改用 `args[3].as<IntImmNode>()->value != 0`（参考 cumsum 用 `as<Bool>().value()`，保持一致）。

#### 4.2.3 Codegen —— Developer 模式（层 7，`codegen_npuir_dev.cc`）

仿 `VcumsumCodegen`（2342）。Developer 模式用 `GetVarValue`/`SetVarValue`（tensor 路径）：

```cpp
void CodeGenTileLangNPUIRDEV::VsortCodegen(const CallNode *op) {
  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
  mlir::Location loc = builder.getUnknownLoc();
  Value src = GetVarValue(npuirop.src);
  Value dst_value = GetVarValue(npuirop.dst_value);
  Value dst_index = GetVarValue(npuirop.dst_index);
  mlir::Type val_type = dst_value.getType();
  mlir::Type idx_type = dst_index.getType();
  mlir::TypeRange result_tensors({val_type, idx_type});
  auto newOp = builder.create<mlir::hivm::VSortOp>(
      loc, result_tensors, src,
      mlir::ValueRange{dst_value, dst_index},
      npuirop.descending, npuirop.sort_axis);
  SetVarValue(npuirop.dst_value, newOp->getResult(0));
  SetVarValue(npuirop.dst_index, newOp->getResult(1));
}
```

dispatch（在 `tl.npuir_gather` 分支后加）：
```cpp
} else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
  VsortCodegen(op);
```

**实现发现**：Developer 模式 codegen 必须用 `SmallVector<mlir::Type, 2>` 构造 result types，而非 `mlir::TypeRange({...})`（后者会导致 VSortOp build 丢弃传入的类型，产生非 tensor/memref 的无效类型）。此外 dev 模式下 dst 必须用 `alloc_shared`（cbuf），Expert 模式下用 `alloc_ub`（ub），因为后端 `hivm.hir.store` 仅支持 GM↔UB 拷贝。

CheckVar pass（dev 独有，4407-4435 段，仿 cumsum 加 3 个 buffer）：
```cpp
} else if (call->op.same_as(Op::Get("tl.npuir_sort"))) {
  tvm::tl::NpuirSort npuirop(call->args, outer_->vmap);
  CheckVar(npuirop.src->data.get());
  CheckVar(npuirop.dst_value->data.get());
  CheckVar(npuirop.dst_index->data.get());
}
```

#### 4.2.4 Codegen —— Expert/API 模式（层 8，`codegen_npuir_api.cc`）

仿 `VcumsumCodegen`（1578）。API 模式用 `GenSubviewFromRegion`（memref 路径）：

```cpp
void CodeGenTileLangNPUIRAPI::VsortCodegen(const CallNode *op) {
  tvm::tl::NpuirSort npuirop(op->args, this->vmap);
  mlir::Location loc = builder.getUnknownLoc();
  Value src = GenSubviewFromRegion(npuirop.src, npuirop.src_range);
  Value dst_value = GenSubviewFromRegion(npuirop.dst_value, npuirop.dst_value_range);
  Value dst_index = GenSubviewFromRegion(npuirop.dst_index, npuirop.dst_index_range);
  builder.create<mlir::hivm::VSortOp>(
      loc, TypeRange{}, src,
      mlir::ValueRange{dst_value, dst_index},
      npuirop.descending, npuirop.sort_axis);
}
```

dispatch（`tl.npuir_gather` 分支后加）：
```cpp
} else if (op->op.same_as(Op::Get("tl.npuir_sort"))) {
  VsortCodegen(op);
```

#### 4.2.5 Codegen —— A5 变体（层 9-10）

`codegen_npuir_api_a5.cc`：直接用 `mlir::hivm::VSortOp`（同 4.2.4，A5 api 也走 `GenSubviewFromRegion`，参考 `VcumsumCodegen` 2316 用 `hivm::VCumsumOp`）。

`codegen_npuir_dev_a5.cc`：A5 dev 对 cumsum 用了 `hfusion::CumsumOp`（无 hivm 等价时退化路径）。vsort **没有** `hfusion::SortOp`，故采用与 A5 api 一致的 `mlir::hivm::VSortOp` + `GenSubviewFromRegion` + `SetVarValue`（参考 A5 dev `VgatherCodegen` 2882 也是 `GenSubviewFromRegion` + `SetVarValue` 混用）。若类型不匹配，退路是在 A5 dev 路径 `ICHECK(false)` 标注「A5 dev 暂不支持 vsort」。

#### 4.2.6 文本 codegen（层 6，`codegen_npuir.cc`，已弃用但保持完整）

仿 `VselectCodegen`（740）手写文本，emit 形如：
```
hivm.hir.vsort ins(%src : <type>) outs(%dst_value, %dst_index : <type>, <type>) descending = <false|true> sort_axis = <-1|n>
```
dispatch（1244 `npuir_select` 后）加 `else if (... "tl.npuir_sort") VsortCodegen(op, os);`。

### 4.3 变体代码生成路径对比

| codegen 文件 | Value 获取 | builder.create | 备注 |
|--------------|-----------|----------------|------|
| `codegen_npuir_dev.cc` | `GetVarValue` | `hivm::VSortOp` + `SetVarValue` ×2 | 主 Developer 路径 |
| `codegen_npuir_api.cc` | `GenSubviewFromRegion` | `hivm::VSortOp` | 主 Expert 路径 |
| `codegen_npuir_dev_a5.cc` | `GenSubviewFromRegion` | `hivm::VSortOp` + `SetVarValue` ×2 | A5，无 hfusion 等价 |
| `codegen_npuir_api_a5.cc` | `GenSubviewFromRegion` | `hivm::VSortOp` | A5 |
| `codegen_npuir.cc` | 文本 | `"hivm.hir.vsort"` 字符串 | 弃用路径，保持完整 |

---

## 5. 数据规格与内存规划

### 5.1 输入输出张量

| 参数 | Shape | dtype | 说明 |
|------|-------|-------|------|
| src | (M, N) | float16/float32 | 输入 |
| dst_value | (M, N) | 同 src | 排序后值 |
| dst_index | (M, N) | int32 | 原始下标 |

### 5.2 内存搬运路径

```
GM[src] --T.copy--> UB[src_ub]
UB[src_ub] --T.vsort--> UB[val_ub], UB[idx_ub]
UB[val_ub] --T.copy--> GM[dst_value]
UB[idx_ub] --T.copy--> GM[dst_index]
```

### 5.3 UB 内存预算（示例 M=4,N=1024,fp16）

| Buffer | Shape | dtype | Bytes |
|--------|-------|-------|-------|
| src_ub | (4,1024) | fp16 | 8192 |
| val_ub | (4,1024) | fp16 | 8192 |
| idx_ub | (4,1024) | int32 | 16384 |
| **总计** | | | 32768 / 192KB ✓ |

---

## 6. Tiling 策略

### 6.1 计算类型

纯 Vector，无 Cube，无归约。单 block 即可（`T.Kernel(1, is_npu=True)`），或按 M 维并行（`T.Kernel(M, is_npu=True)`，每 block 处理一行）。

### 6.2 约束分析

- **硬件约束**：VSortOp 目前只支持尾轴排序 → `sort_axis` 只能取 `-1` 或最后一维。设计中前端校验：若 `sort_axis != -1` 且非最后一轴，给出明确报错。
- **元素类型**：仅 fp16/fp32；`dst_index` 用 int32。
- **UB 容量**：单 block 内 src+val+idx 需 < 192KB，按 block_N 控制。

---

## 7. 同步策略

自动同步。`vsort` 在单 block 内完成，无跨核协作、无流水线、无需手动 `sync_block_set/wait`。

---

## 8. 验证方案

### 8.1 Golden 函数（PyTorch）

```python
def golden_vsort(src, descending=False):
    # torch.sort 返回 (values, indices)
    values, indices = torch.sort(src, dim=-1, descending=descending, stable=False)
    return values, indices.to(torch.int32)
```

### 8.2 精度标准

| dtype | atol | rtol |
|-------|------|------|
| float16 | 1e-3 | 1e-3 |
| float32 | 1e-4 | 1e-4 |
| int32 (index) | 0 (exact) | 0 |

> 下标必须精确匹配；排序值若有重复元素，下标可能与 PyTorch 不完全一致（排序稳定性差异），此时用「值匹配 + 下标指向的值匹配」双重校验。

### 8.3 L0 门槛测试计划（本设计阶段定义，develop 阶段实现）

| 用例 | shape | descending | sort_axis | 说明 |
|------|-------|-------------|-----------|------|
| L0-1 | (1, 1024) fp16 | False | -1 | 基本升序 |
| L0-2 | (1, 1024) fp16 | True | -1 | 降序 |
| L0-3 | (4, 1024) fp16 | False | -1 | 多行 |
| L0-4 | (4, 1024) fp32 | False | -1 | fp32 |
| L0-5 | (2, 64) fp16 | True | -1 | 小 shape + 重复元素 |

完整 L1/L2/边界用例交由 `tilelang-op-develop` 阶段实现，放 `testing/npuir/sort_ops/`。

---

## 9. 文档计划

按 AGENTS.md「Docs Auto Routing Rules」，`vsort` 属 Vector 规约/排序类，文档落点：
- 新增 `docs/Tilelang.language/规约操作/T.vsort.md`（API 语义、签名、约束、示例）

---

## 10. 风险点与注意事项

### 10.1 已知约束

| 风险 | 说明 | 处置 |
|------|------|------|
| 仅尾轴排序 | VSortOp description 明确「only tail axis」 | 前端校验 `sort_axis`，非尾轴直接报错 |
| 元素类型受限 | 仅 F16/F32 | 前端校验 dtype；bf16 不自动接入（除非加 `legalize_npuir_bf16`） |
| 重复元素下标不稳定 | 排序算法可能给不同下标 | 测试用「值匹配」校验，下标按「指向值」校验 |
| A5 dev 无 hfusion 等价 | vsort 没有 `hfusion::SortOp` | A5 dev 直接用 `hivm::VSortOp`；若 type 不符则 `ICHECK` 标注 |
| 2 输出 builder 形态 | `ValueRange{val, idx}` 顺序需与 `.td` `dst` 顺序一致 | 严格按 [dst_value, dst_index] 顺序传 |

### 10.2 常见错误预判

| 错误 | 触发场景 | 解决 |
|------|----------|------|
| `tl.npuir_sort` 未注册 | 忘记 `TIR_REGISTER_TL_OP` | 检查 ascend.cc 注册块 |
| `as<Bool>()` 返回 nullptr | 前端 bool 未包成 `tir.const` | 前端用 `tir.const(descending, "bool")` 或改 C++ 用 `IntImmNode` |
| MLIR verifier 失败 | dst_value/dst_index 类型与 src rank 不一致 | 前端校验 shape 一致 |
| `CheckVar` 缺失（dev） | 漏加 4.2.3 CheckVar 分支 | 必须加 3 个 buffer 的 CheckVar |

---

## 11. 交付清单

### 11.1 文件清单

| 文件 | 状态 | 说明 |
|------|------|------|
| `examples/vsort/DESIGN.md` | ✅ 本文档 | 设计文档 |
| `tilelang/language/customize_npuir.py` | ⬜ 改 | 新增 `npuir_sort` |
| `tilelang/language/__init__.py` | ⬜ 改 | 导出 `vsort` |
| `src/op/ascend.h` / `ascend.cc` | ⬜ 改 | `NpuirSort` 类 + 注册 |
| `src/target/codegen_npuir_dev.cc` / `.h` | ⬜ 改 | Developer VsortCodegen + dispatch + CheckVar |
| `src/target/codegen_npuir_api.cc` / `.h` | ⬜ 改 | Expert VsortCodegen + dispatch |
| `src/target/codegen_npuir_dev_a5.cc` / `.h` | ⬜ 改 | A5 dev VsortCodegen + dispatch |
| `src/target/codegen_npuir_api_a5.cc` / `.h` | ⬜ 改 | A5 api VsortCodegen + dispatch |
| `src/target/codegen_npuir.cc` / `.h` | ⬜ 改 | 文本 VsortCodegen + dispatch |
| `testing/npuir/sort_ops/test_vsort_dev.py` | ⬜ 新增 | Developer 模式测试 |
| `testing/npuir/sort_ops/test_vsort_exp.py` | ⬜ 新增 | Expert 模式测试 |
| `docs/Tilelang.language/规约操作/T.vsort.md` | ⬜ 新增 | API 文档 |

### 11.2 实现顺序

1. ✅ 设计文档（DESIGN.md）
2. ✅ 前端 `npuir_sort` + 导出 `vsort`
3. ✅ C++ op 类 `NpuirSort` + 注册
4. ✅ 5 个 codegen `VsortCodegen` + dispatch
5. ✅ 编译通过（需同时 build `tilelang` 和 `tilelang_module` 两个 target）
6. ✅ L0 测试 `test_vsort_dev.py`（4 passed）+ `test_vsort_exp.py`（4 passed）
7. ✅ 文档 `T.vsort.md`
8. ⬜ `format.sh --files` 格式校验