### PR TITLE
ci: test linux-aarch64-a3-800i-2 runner label

### DIFF
--- a/.github/workflows/test_npuir_wheel.yml
+++ b/.github/workflows/test_npuir_wheel.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    runs-on: linux-aarch64-a3-2
+    runs-on: linux-aarch64-a3-800i-x
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
     timeout-minutes: 120

--- a/.github/workflows/test_npuir_wheel.yml
+++ b/.github/workflows/test_npuir_wheel.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    runs-on: linux-aarch64-a3-800i-x
+    runs-on: linux-aarch64-a3-800i-2
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
     timeout-minutes: 120


### PR DESCRIPTION
## Summary
Test the newly-added `linux-aarch64-a3-800i-x` self-hosted runner label.

## Changes
- Change `runs-on` in `.github/workflows/test_npuir_wheel.yml` from `linux-aarch64-a3-2` to `linux-aarch64-a3-800i-x`.

## Purpose
Validate that the new 800i resource-pool label dispatches the NPU test job correctly (local cn12-001 + remote aiframework/mind). This is a temporary validation PR and may be closed without merging.