### PR TITLE
[hotfix] Fix concurrent compilation race in NPUUtils init

### DIFF
--- a/tilelang/utils/npu_utils.py
+++ b/tilelang/utils/npu_utils.py
@@ -60,9 +60,14 @@ class NPUUtils(object):
                 # compile npu_utils.so
                 with tempfile.TemporaryDirectory() as tmpdir:
                     dst_path = os.path.join(tmpdir, "npu_utils.cxx")
+                    output_path = os.path.join(tmpdir, "npu_utils.so")
                     safe_copy(npu_utils_cpp, dst_path)
                     so = build_npu_ext(
-                        "npu_utils", None, dst_path, kernel_launcher="torch"
+                        "npu_utils",
+                        None,
+                        dst_path,
+                        kernel_launcher="torch",
+                        output_path=output_path,
                     )
                     safe_copy(so, fname_path)
         else:


### PR DESCRIPTION
Pass output_path to build_npu_ext so the .so is written inside the per-invocation tmpdir instead of the CWD. Without this, concurrent NPUUtils initializers race on the same 'npu_utils.so' output file, causing one compile to overwrite or read a half-written artifact from another.